### PR TITLE
Phase 1: HPE Header & Footer — Global Components

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -1,8 +1,13 @@
 @import url('./footer-tokens.css');
 
+/* ===== FOOTER BASE ===== */
+
 footer {
-  background-color: var(--light-color);
+  background-color: var(--dark-color);
+  color: var(--text-light-color);
+  font-family: var(--footer-font-family);
   font-size: var(--body-font-size-xs);
+  line-height: 1.5;
 }
 
 footer .footer > div {
@@ -15,8 +20,352 @@ footer .footer p {
   margin: 0;
 }
 
+footer .footer a {
+  color: var(--text-light-color);
+  text-decoration: none;
+  transition: color var(--transition-base);
+}
+
+footer .footer a:hover {
+  color: var(--color-hpe-green);
+  text-decoration: underline;
+}
+
+/* ===== TOP BAR ===== */
+
+footer .footer .footer-top-bar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  padding-bottom: var(--spacing-l);
+}
+
+footer .footer .footer-logo {
+  flex-shrink: 0;
+}
+
+footer .footer .footer-logo a {
+  display: inline-block;
+}
+
+footer .footer .footer-logo img {
+  height: 40px;
+  width: auto;
+  display: block;
+  filter: brightness(0) invert(1);
+}
+
+/* Action links */
+footer .footer .footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-xs) var(--spacing-s);
+}
+
+footer .footer .footer-action-link {
+  color: var(--text-light-color);
+  font-size: var(--body-font-size-xs);
+  padding: 6px 0;
+}
+
+footer .footer .footer-action-button {
+  display: inline-block;
+  border: 1px solid rgb(255 255 255 / 40%);
+  border-radius: var(--button-border-radius);
+  padding: 6px 16px;
+  color: var(--text-light-color);
+  font-size: var(--body-font-size-xs);
+  font-weight: 500;
+  transition: border-color var(--transition-base), background-color var(--transition-base);
+}
+
+footer .footer .footer-action-button:hover {
+  border-color: var(--text-light-color);
+  background-color: rgb(255 255 255 / 10%);
+  text-decoration: none;
+}
+
+/* Social icons */
+footer .footer .footer-social {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+footer .footer .footer-social-label {
+  font-size: var(--body-font-size-xs);
+  color: rgb(255 255 255 / 70%);
+  margin-right: var(--spacing-xs);
+}
+
+footer .footer .footer-social-icons {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+footer .footer .footer-social-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  transition: background-color var(--transition-base);
+}
+
+footer .footer .footer-social-link:hover {
+  background-color: rgb(255 255 255 / 10%);
+  text-decoration: none;
+}
+
+footer .footer .footer-social-link .icon {
+  width: 20px;
+  height: 20px;
+}
+
+footer .footer .footer-social-link .icon img {
+  filter: brightness(0) invert(1);
+}
+
+/* ===== NAV COLUMNS ===== */
+
+footer .footer .footer-nav {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-l) 0;
+}
+
+footer .footer .footer-nav-column {
+  border-bottom: 1px solid rgb(255 255 255 / 15%);
+}
+
+footer .footer .footer-nav-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--spacing-s) 0;
+  background: none;
+  border: none;
+  color: var(--text-light-color);
+  cursor: pointer;
+  margin: 0;
+  font-family: var(--footer-font-family);
+}
+
+footer .footer .footer-nav-toggle:hover {
+  background: none;
+}
+
+footer .footer .footer-nav-title {
+  font-family: var(--heading-font-family);
+  font-size: var(--body-font-size-xs);
+  font-weight: 600;
+  color: var(--text-light-color);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0;
+}
+
+footer .footer .footer-nav-arrow {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--text-light-color);
+  border-bottom: 2px solid var(--text-light-color);
+  transform: rotate(45deg);
+  transition: transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+footer .footer .footer-nav-toggle[aria-expanded="true"] .footer-nav-arrow {
+  transform: rotate(-135deg);
+}
+
+footer .footer .footer-nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 var(--spacing-xs);
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height var(--transition-slow), padding var(--transition-slow);
+}
+
+footer .footer .footer-nav-toggle[aria-expanded="true"] + .footer-nav-list {
+  max-height: 500px;
+  padding-bottom: var(--spacing-s);
+}
+
+footer .footer .footer-nav-list li {
+  padding: 4px 0;
+}
+
+footer .footer .footer-nav-list a {
+  font-size: var(--body-font-size-xs);
+  color: rgb(255 255 255 / 80%);
+  line-height: 1.8;
+}
+
+footer .footer .footer-nav-list a:hover {
+  color: var(--text-light-color);
+}
+
+/* ===== SEPARATOR ===== */
+
+footer .footer .footer-separator {
+  border: none;
+  border-top: 1px solid rgb(255 255 255 / 20%);
+  margin: 0;
+}
+
+/* ===== COPYRIGHT BAR ===== */
+
+footer .footer .footer-copyright {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+  padding-top: var(--spacing-m);
+  padding-bottom: var(--spacing-s);
+}
+
+footer .footer .footer-copyright-text {
+  font-size: 12px;
+  color: rgb(255 255 255 / 60%);
+  margin: 0;
+}
+
+footer .footer .footer-legal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px var(--spacing-s);
+}
+
+footer .footer .footer-legal-list li {
+  position: relative;
+}
+
+footer .footer .footer-legal-list li:not(:last-child)::after {
+  content: '|';
+  position: absolute;
+  right: calc(-1 * var(--spacing-xs));
+  color: rgb(255 255 255 / 40%);
+}
+
+footer .footer .footer-legal-list a {
+  font-size: 12px;
+  color: rgb(255 255 255 / 60%);
+}
+
+footer .footer .footer-legal-list a:hover {
+  color: var(--text-light-color);
+}
+
+footer .footer .footer-language {
+  margin-top: var(--spacing-xs);
+}
+
+footer .footer .footer-language-link {
+  font-size: 12px;
+  color: rgb(255 255 255 / 60%);
+  border: 1px solid rgb(255 255 255 / 30%);
+  border-radius: 4px;
+  padding: 4px 12px;
+  display: inline-block;
+}
+
+footer .footer .footer-language-link:hover {
+  color: var(--text-light-color);
+  border-color: rgb(255 255 255 / 60%);
+  text-decoration: none;
+}
+
+/* ===== TABLET (600px+) ===== */
+
+@media (width >= 600px) {
+  footer .footer .footer-top-bar {
+    flex-flow: row wrap;
+    align-items: center;
+  }
+
+  footer .footer .footer-actions {
+    flex: 1;
+    justify-content: flex-start;
+  }
+
+  footer .footer .footer-copyright {
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+/* ===== DESKTOP (900px+) ===== */
+
 @media (width >= 900px) {
   footer .footer > div {
     padding: var(--footer-padding-desktop);
+  }
+
+  footer .footer .footer-top-bar {
+    gap: var(--spacing-l);
+  }
+
+  footer .footer .footer-nav {
+    flex-direction: row;
+    gap: var(--spacing-l);
+  }
+
+  footer .footer .footer-nav-column {
+    flex: 1;
+    border-bottom: none;
+  }
+
+  /* Hide accordion toggle on desktop, show title directly */
+  footer .footer .footer-nav-toggle {
+    cursor: default;
+    padding: 0 0 var(--spacing-s);
+  }
+
+  footer .footer .footer-nav-arrow {
+    display: none;
+  }
+
+  footer .footer .footer-nav-list {
+    max-height: none;
+    overflow: visible;
+    padding: 0;
+  }
+
+  footer .footer .footer-nav-toggle[aria-expanded="true"] + .footer-nav-list,
+  footer .footer .footer-nav-toggle[aria-expanded="false"] + .footer-nav-list {
+    max-height: none;
+    padding: 0;
+  }
+
+  footer .footer .footer-social {
+    margin-left: auto;
+  }
+
+  footer .footer .footer-copyright {
+    gap: var(--spacing-m);
+  }
+
+  footer .footer .footer-language {
+    margin-top: 0;
+    margin-left: auto;
+  }
+}
+
+/* ===== WIDE (1200px+) ===== */
+
+@media (width >= 1200px) {
+  footer .footer .footer-nav {
+    gap: var(--spacing-xl);
   }
 }

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -2,19 +2,226 @@ import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 
 /**
- * loads and decorates the footer
+ * Builds the top bar section with logo, action links, social icons
+ * @param {Element} section The raw section element
+ * @returns {Element} The decorated top bar
+ */
+function buildTopBar(section) {
+  const topBar = document.createElement('div');
+  topBar.className = 'footer-top-bar';
+
+  // Logo
+  const logoP = section.querySelector('p:has(a img)');
+  if (logoP) {
+    const logoLink = logoP.querySelector('a');
+    const logoDiv = document.createElement('div');
+    logoDiv.className = 'footer-logo';
+    logoDiv.append(logoLink);
+    topBar.append(logoDiv);
+  }
+
+  const lists = section.querySelectorAll('ul');
+  const paragraphs = [...section.querySelectorAll('p')];
+
+  // Action links (first ul)
+  if (lists.length > 0) {
+    const actionsDiv = document.createElement('div');
+    actionsDiv.className = 'footer-actions';
+    const actionList = lists[0];
+    [...actionList.children].forEach((li) => {
+      const link = li.querySelector('a');
+      if (link) {
+        const isButton = li.querySelector('strong');
+        if (isButton) {
+          link.className = 'footer-action-button';
+        } else {
+          link.className = 'footer-action-link';
+        }
+        actionsDiv.append(link);
+      }
+    });
+    topBar.append(actionsDiv);
+  }
+
+  // Social icons (second ul)
+  if (lists.length > 1) {
+    const socialDiv = document.createElement('div');
+    socialDiv.className = 'footer-social';
+
+    // Find the "Follow HPE on" text
+    const followText = paragraphs.find((p) => p.textContent.trim().startsWith('Follow'));
+    if (followText) {
+      const label = document.createElement('span');
+      label.className = 'footer-social-label';
+      label.textContent = followText.textContent.trim();
+      socialDiv.append(label);
+    }
+
+    const socialList = document.createElement('div');
+    socialList.className = 'footer-social-icons';
+    [...lists[1].children].forEach((li) => {
+      const link = li.querySelector('a');
+      if (link) {
+        link.className = 'footer-social-link';
+        socialList.append(link);
+      }
+    });
+    socialDiv.append(socialList);
+    topBar.append(socialDiv);
+  }
+
+  return topBar;
+}
+
+/**
+ * Builds the nav columns section
+ * @param {Element} section The raw section element
+ * @returns {Element} The decorated nav columns
+ */
+function buildNavColumns(section) {
+  const navColumns = document.createElement('div');
+  navColumns.className = 'footer-nav';
+
+  const headings = section.querySelectorAll('h3');
+  headings.forEach((heading) => {
+    const column = document.createElement('div');
+    column.className = 'footer-nav-column';
+
+    // Column heading
+    const title = document.createElement('h4');
+    title.className = 'footer-nav-title';
+    title.textContent = heading.textContent;
+
+    // Accordion button for mobile
+    const toggle = document.createElement('button');
+    toggle.className = 'footer-nav-toggle';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', heading.textContent);
+    toggle.append(title);
+
+    const arrow = document.createElement('span');
+    arrow.className = 'footer-nav-arrow';
+    toggle.append(arrow);
+
+    column.append(toggle);
+
+    // Links list
+    const list = heading.nextElementSibling;
+    if (list && list.tagName === 'UL') {
+      list.className = 'footer-nav-list';
+      list.setAttribute('role', 'list');
+      column.append(list);
+    }
+
+    // Mobile accordion toggle
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      // Close all other columns
+      navColumns.querySelectorAll('.footer-nav-toggle').forEach((t) => {
+        t.setAttribute('aria-expanded', 'false');
+      });
+      if (!expanded) {
+        toggle.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    navColumns.append(column);
+  });
+
+  return navColumns;
+}
+
+/**
+ * Builds the copyright bar section
+ * @param {Element} section The raw section element
+ * @returns {Element} The decorated copyright bar
+ */
+function buildCopyrightBar(section) {
+  const copyrightBar = document.createElement('div');
+  copyrightBar.className = 'footer-copyright';
+
+  const paragraphs = section.querySelectorAll('p');
+  const list = section.querySelector('ul');
+
+  // Copyright text
+  if (paragraphs.length > 0) {
+    const copyText = document.createElement('p');
+    copyText.className = 'footer-copyright-text';
+    copyText.textContent = paragraphs[0].textContent;
+    copyrightBar.append(copyText);
+  }
+
+  // Legal links
+  if (list) {
+    const legalNav = document.createElement('nav');
+    legalNav.className = 'footer-legal';
+    legalNav.setAttribute('aria-label', 'Legal');
+    const legalList = document.createElement('ul');
+    legalList.className = 'footer-legal-list';
+    [...list.children].forEach((li) => {
+      const link = li.querySelector('a');
+      if (link) {
+        const legalItem = document.createElement('li');
+        legalItem.append(link);
+        legalList.append(legalItem);
+      }
+    });
+    legalNav.append(legalList);
+    copyrightBar.append(legalNav);
+  }
+
+  // Language selector
+  if (paragraphs.length > 1) {
+    const langLink = paragraphs[paragraphs.length - 1].querySelector('a');
+    if (langLink) {
+      const langDiv = document.createElement('div');
+      langDiv.className = 'footer-language';
+      langLink.className = 'footer-language-link';
+      langDiv.append(langLink);
+      copyrightBar.append(langDiv);
+    }
+  }
+
+  return copyrightBar;
+}
+
+/**
+ * Loads and decorates the footer
  * @param {Element} block The footer block element
  */
 export default async function decorate(block) {
-  // load footer as fragment
   const footerMeta = getMetadata('footer');
-  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/content/footer';
   const fragment = await loadFragment(footerPath);
 
-  // decorate footer DOM
   block.textContent = '';
+
+  if (!fragment) return;
+
   const footer = document.createElement('div');
-  while (fragment.firstElementChild) footer.append(fragment.firstElementChild);
+
+  // Get sections from fragment
+  const sections = fragment.querySelectorAll(':scope .section');
+  const sectionElements = sections.length > 0
+    ? [...sections]
+    : [...fragment.querySelectorAll(':scope > div > div')];
+
+  if (sectionElements.length >= 1) {
+    footer.append(buildTopBar(sectionElements[0]));
+  }
+
+  if (sectionElements.length >= 2) {
+    footer.append(buildNavColumns(sectionElements[1]));
+  }
+
+  // Separator
+  const hr = document.createElement('hr');
+  hr.className = 'footer-separator';
+  footer.append(hr);
+
+  if (sectionElements.length >= 3) {
+    footer.append(buildCopyrightBar(sectionElements[2]));
+  }
 
   block.append(footer);
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,13 +1,17 @@
 @import url('./header-tokens.css');
 
-/* header and nav layout */
+/* ===== NAV WRAPPER ===== */
 header .nav-wrapper {
-  background-color: var(--background-color);
+  background-color: var(--dark-color);
+  color: rgb(212 212 212);
   width: 100%;
   z-index: 2;
   position: fixed;
+  top: 0;
+  left: 0;
 }
 
+/* ===== NAV LAYOUT ===== */
 header nav {
   box-sizing: border-box;
   display: grid;
@@ -25,26 +29,12 @@ header nav {
 
 header nav[aria-expanded='true'] {
   grid-template:
-    'hamburger brand' var(--nav-height)
-    'sections sections' 1fr
-    'tools tools' var(--nav-height) / auto 1fr;
+    'hamburger brand tools' var(--nav-height)
+    'sections sections sections' 1fr / auto 1fr auto;
   overflow-y: auto;
   min-height: 100dvh;
-}
-
-@media (width >= 900px) {
-  header nav {
-    display: flex;
-    justify-content: space-between;
-    gap: 0 var(--header-nav-gap-desktop);
-    max-width: var(--header-nav-max-width-desktop);
-    padding: var(--header-nav-padding-desktop);
-  }
-
-  header nav[aria-expanded='true'] {
-    min-height: 0;
-    overflow: visible;
-  }
+  height: auto;
+  background-color: var(--dark-color);
 }
 
 header nav p {
@@ -53,10 +43,16 @@ header nav p {
 }
 
 header nav a {
-  color: currentcolor;
+  color: rgb(212 212 212);
+  text-decoration: none;
 }
 
-/* hamburger */
+header nav a:hover {
+  color: var(--text-light-color);
+  text-decoration: none;
+}
+
+/* ===== HAMBURGER (mobile) ===== */
 header nav .nav-hamburger {
   grid-area: hamburger;
   height: var(--header-hamburger-size);
@@ -70,11 +66,12 @@ header nav .nav-hamburger button {
   border: 0;
   border-radius: 0;
   padding: 0;
-  background-color: var(--background-color);
-  color: inherit;
+  background-color: transparent;
+  color: rgb(212 212 212);
   overflow: initial;
   text-overflow: initial;
   white-space: initial;
+  cursor: pointer;
 }
 
 header nav .nav-hamburger-icon,
@@ -130,15 +127,8 @@ header nav[aria-expanded='true'] .nav-hamburger-icon::after {
   transform: rotate(-45deg);
 }
 
-@media (width >= 900px) {
-  header nav .nav-hamburger {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-/* brand */
-header .nav-brand {
+/* ===== BRAND / LOGO ===== */
+header nav .nav-brand {
   grid-area: brand;
   flex-basis: var(--header-brand-width);
   font-size: var(--heading-font-size-s);
@@ -149,9 +139,15 @@ header .nav-brand {
 header nav .nav-brand img {
   width: var(--header-brand-width);
   height: auto;
+  display: block;
 }
 
-/* sections */
+header nav .nav-brand a {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* ===== NAV SECTIONS (primary links) ===== */
 header nav .nav-sections {
   grid-area: sections;
   flex: 1 1 auto;
@@ -163,27 +159,101 @@ header nav[aria-expanded='true'] .nav-sections {
   display: block;
   visibility: visible;
   align-self: start;
+  padding-top: var(--spacing-s);
 }
 
 header nav .nav-sections ul {
   list-style: none;
   padding-left: 0;
-  font-size: var(--body-font-size-s);
+  margin: 0;
 }
 
-header nav .nav-sections ul > li {
-  font-weight: 500;
+header nav .nav-sections .default-content-wrapper > ul > li {
+  margin: 0;
 }
 
-header nav .nav-sections ul > li > ul {
-  margin-top: 0;
-}
-
-header nav .nav-sections ul > li > ul > li {
+header nav .nav-sections .default-content-wrapper > ul > li > a {
+  display: inline-block;
+  padding: 12px 0;
+  font-size: var(--body-font-size-m);
   font-weight: 400;
+  color: rgb(212 212 212);
+  border-bottom: 1px solid rgb(255 255 255 / 10%);
+  width: 100%;
 }
 
+header nav .nav-sections .default-content-wrapper > ul > li > a:hover {
+  color: var(--text-light-color);
+}
+
+/* ===== TOOLS (search + language) ===== */
+header nav .nav-tools {
+  grid-area: tools;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+header nav .nav-tools-search {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  border: none;
+  padding: 8px;
+  background: transparent;
+  color: rgb(212 212 212);
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background-color var(--transition-base);
+}
+
+header nav .nav-tools-search:hover {
+  background-color: rgb(255 255 255 / 10%);
+  color: var(--text-light-color);
+}
+
+header nav .nav-tools-search .icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+}
+
+header nav .nav-tools-lang {
+  display: none;
+  font-size: var(--body-font-size-xs);
+  font-weight: 500;
+  color: rgb(212 212 212);
+  padding: 4px 8px;
+  border-radius: var(--button-border-radius);
+  transition: color var(--transition-base);
+}
+
+header nav .nav-tools-lang:hover {
+  color: var(--text-light-color);
+}
+
+/* ===== DESKTOP (900px+) ===== */
 @media (width >= 900px) {
+  header nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0 var(--header-nav-gap-desktop);
+    max-width: var(--header-nav-max-width-desktop);
+    padding: var(--header-nav-padding-desktop);
+  }
+
+  header nav[aria-expanded='true'] {
+    min-height: 0;
+    overflow: visible;
+  }
+
+  header nav .nav-hamburger {
+    display: none;
+    visibility: hidden;
+  }
+
   header nav .nav-sections {
     display: block;
     visibility: visible;
@@ -192,38 +262,14 @@ header nav .nav-sections ul > li > ul > li {
 
   header nav[aria-expanded='true'] .nav-sections {
     align-self: unset;
-  }
-
-  header nav .nav-sections .nav-drop {
-    position: relative;
-    padding-right: 16px;
-    cursor: pointer;
-  }
-
-  header nav .nav-sections .nav-drop::after {
-    content: '';
-    display: inline-block;
-    position: absolute;
-    top: 2px;
-    right: 2px;
-    transform: rotate(135deg);
-    width: 6px;
-    height: 6px;
-    border: 2px solid currentcolor;
-    border-radius: 0 1px 0 0;
-    border-width: 2px 2px 0 0;
-  }
-
-  header nav .nav-sections .nav-drop[aria-expanded='true']::after {
-    top: unset;
-    bottom: 2px;
-    transform: rotate(315deg);
+    padding-top: 0;
   }
 
   header nav .nav-sections ul {
     display: flex;
-    gap: var(--header-nav-gap);
+    gap: 0;
     margin: 0;
+    align-items: center;
   }
 
   header nav .nav-sections .default-content-wrapper > ul > li {
@@ -231,94 +277,24 @@ header nav .nav-sections ul > li > ul > li {
     position: relative;
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li > ul {
-    display: none;
-    position: relative;
+  header nav .nav-sections .default-content-wrapper > ul > li > a {
+    display: inline-block;
+    padding: 8px 12px;
+    font-size: var(--body-font-size-m);
+    font-weight: 400;
+    color: rgb(212 212 212);
+    border-radius: var(--button-border-radius);
+    border-bottom: none;
+    width: auto;
+    transition: background-color var(--transition-base), color var(--transition-base);
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded='true'] > ul {
-    display: block;
-    position: absolute;
-    left: var(--header-dropdown-left);
-    width: var(--header-dropdown-width);
-    top: 150%;
-    padding: var(--header-dropdown-padding);
-    background-color: var(--light-color);
-    white-space: initial;
-    z-index: 1;
+  header nav .nav-sections .default-content-wrapper > ul > li > a:hover {
+    background-color: rgb(255 255 255 / 10%);
+    color: var(--text-light-color);
   }
 
-  header nav .nav-sections .default-content-wrapper > ul > li > ul::before {
-    content: '';
-    position: absolute;
-    top: -8px;
-    left: var(--header-dropdown-padding);
-    width: 0;
-    height: 0;
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
-    border-bottom: 8px solid var(--light-color);
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li > ul > li {
-    padding: 8px 0;
-  }
-}
-
-/* tools */
-header nav .nav-tools {
-  grid-area: tools;
-}
-
-header nav .nav-tools .button {
-  margin: 0;
-  border: none;
-  padding: 0.5em;
-  background: none;
-  line-height: 0;
-}
-
-/* breadcrumbs */
-header .breadcrumbs {
-  display: none;
-  margin: auto;
-  max-width: var(--header-nav-max-width);
-  height: var(--breadcrumbs-height);
-  padding: var(--header-nav-padding);
-  font-size: var(--body-font-size-xs);
-  overflow: hidden;
-}
-
-header .breadcrumbs ol {
-  display: flex;
-  flex-flow: wrap;
-  list-style: none;
-  padding: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  gap: 1ch;
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-header .breadcrumbs ol li {
-  padding: 0;
-  color: var(--dark-color);
-}
-
-header .breadcrumbs ol li:not(:last-child)::after {
-  content: '/';
-  padding-left: 1ch;
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-header .breadcrumbs ol li[aria-current] {
-  color: var(--text-color);
-}
-
-@media (width >= 900px) {
-  header .breadcrumbs {
-    display: block;
-    max-width: var(--header-nav-max-width-desktop);
-    padding: var(--header-nav-padding-desktop);
+  header nav .nav-tools-lang {
+    display: inline-block;
   }
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,253 +1,128 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 
-// media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');
 
-function closeOnEscape(e) {
-  if (e.code === 'Escape') {
-    const nav = document.getElementById('nav');
-    const navSections = nav.querySelector('.nav-sections');
-    if (!navSections) return;
-    const navSectionExpanded = navSections.querySelector('[aria-expanded="true"]');
-    if (navSectionExpanded && isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleAllNavSections(navSections);
-      navSectionExpanded.focus();
-    } else if (!isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleMenu(nav, navSections);
-      nav.querySelector('button').focus();
-    }
-  }
-}
-
-function closeOnFocusLost(e) {
-  const nav = e.currentTarget;
-  if (!nav.contains(e.relatedTarget)) {
-    const navSections = nav.querySelector('.nav-sections');
-    if (!navSections) return;
-    const navSectionExpanded = navSections.querySelector('[aria-expanded="true"]');
-    if (navSectionExpanded && isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleAllNavSections(navSections, false);
-    } else if (!isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleMenu(nav, navSections, false);
-    }
-  }
-}
-
-function openOnKeydown(e) {
-  const focused = document.activeElement;
-  const isNavDrop = focused.className === 'nav-drop';
-  if (isNavDrop && (e.code === 'Enter' || e.code === 'Space')) {
-    const dropExpanded = focused.getAttribute('aria-expanded') === 'true';
-    // eslint-disable-next-line no-use-before-define
-    toggleAllNavSections(focused.closest('.nav-sections'));
-    focused.setAttribute('aria-expanded', dropExpanded ? 'false' : 'true');
-  }
-}
-
-function focusNavSection() {
-  document.activeElement.addEventListener('keydown', openOnKeydown);
-}
-
 /**
- * Toggles all nav sections
- * @param {Element} sections The container element
- * @param {Boolean} expanded Whether the element should be expanded or collapsed
+ * Toggles the mobile nav open/closed.
+ * @param {Element} nav The nav element
+ * @param {boolean|null} forceExpanded Force a specific state
  */
-function toggleAllNavSections(sections, expanded = false) {
-  if (!sections) return;
-  sections.querySelectorAll('.nav-sections .default-content-wrapper > ul > li').forEach((section) => {
-    section.setAttribute('aria-expanded', expanded);
-  });
-}
-
-/**
- * Toggles the entire nav
- * @param {Element} nav The container element
- * @param {Element} navSections The nav sections within the container element
- * @param {*} forceExpanded Optional param to force nav expand behavior when not null
- */
-function toggleMenu(nav, navSections, forceExpanded = null) {
-  const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
+function toggleMenu(nav, forceExpanded = null) {
+  const expanded = forceExpanded !== null
+    ? !forceExpanded
+    : nav.getAttribute('aria-expanded') === 'true';
   const button = nav.querySelector('.nav-hamburger button');
   document.body.style.overflowY = (expanded || isDesktop.matches) ? '' : 'hidden';
   nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-  toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');
-  // enable nav dropdown keyboard accessibility
-  if (navSections) {
-    const navDrops = navSections.querySelectorAll('.nav-drop');
-    if (isDesktop.matches) {
-      navDrops.forEach((drop) => {
-        if (!drop.hasAttribute('tabindex')) {
-          drop.setAttribute('tabindex', 0);
-          drop.addEventListener('focus', focusNavSection);
-        }
-      });
-    } else {
-      navDrops.forEach((drop) => {
-        drop.removeAttribute('tabindex');
-        drop.removeEventListener('focus', focusNavSection);
-      });
-    }
-  }
-
-  // enable menu collapse on escape keypress
-  if (!expanded || isDesktop.matches) {
-    // collapse menu on escape press
-    window.addEventListener('keydown', closeOnEscape);
-    // collapse menu on focus lost
-    nav.addEventListener('focusout', closeOnFocusLost);
-  } else {
-    window.removeEventListener('keydown', closeOnEscape);
-    nav.removeEventListener('focusout', closeOnFocusLost);
-  }
-}
-
-function getDirectTextContent(menuItem) {
-  const menuLink = menuItem.querySelector(':scope > :where(a,p)');
-  if (menuLink) {
-    return menuLink.textContent.trim();
-  }
-  return Array.from(menuItem.childNodes)
-    .filter((n) => n.nodeType === Node.TEXT_NODE)
-    .map((n) => n.textContent)
-    .join(' ');
-}
-
-const MAX_BREADCRUMB_DEPTH = 20;
-
-async function buildBreadcrumbsFromNavTree(nav, currentUrl) {
-  const crumbs = [];
-
-  const homeUrl = document.querySelector('.nav-brand a[href]').href;
-
-  let menuItem = Array.from(nav.querySelectorAll('a')).find((a) => a.href === currentUrl);
-  if (menuItem) {
-    let depth = 0;
-    do {
-      const link = menuItem.querySelector(':scope > a');
-      crumbs.unshift({ title: getDirectTextContent(menuItem), url: link ? link.href : null });
-      menuItem = menuItem.closest('ul')?.closest('li');
-      depth += 1;
-    } while (menuItem && depth < MAX_BREADCRUMB_DEPTH);
-  } else if (currentUrl !== homeUrl) {
-    crumbs.unshift({ title: getMetadata('og:title'), url: currentUrl });
-  }
-
-  crumbs.unshift({ title: 'Home', url: homeUrl });
-
-  // last link is current page and should not be linked
-  if (crumbs.length > 1) {
-    crumbs.at(-1).url = null;
-  }
-  crumbs.at(-1)['aria-current'] = 'page';
-  return crumbs;
-}
-
-async function buildBreadcrumbs() {
-  const breadcrumbs = document.createElement('nav');
-  breadcrumbs.className = 'breadcrumbs';
-
-  const crumbs = await buildBreadcrumbsFromNavTree(document.querySelector('.nav-sections'), document.location.href);
-
-  const ol = document.createElement('ol');
-  ol.append(...crumbs.map((item) => {
-    const li = document.createElement('li');
-    if (item['aria-current']) li.setAttribute('aria-current', item['aria-current']);
-    if (item.url) {
-      const a = document.createElement('a');
-      a.href = item.url;
-      a.textContent = item.title;
-      li.append(a);
-    } else {
-      li.textContent = item.title;
-    }
-    return li;
-  }));
-
-  breadcrumbs.append(ol);
-  return breadcrumbs;
 }
 
 /**
- * loads and decorates the header, mainly the nav
+ * Closes mobile nav on Escape key.
+ * @param {KeyboardEvent} e keyboard event
+ */
+function closeOnEscape(e) {
+  if (e.code === 'Escape') {
+    const nav = document.getElementById('nav');
+    if (nav && nav.getAttribute('aria-expanded') === 'true' && !isDesktop.matches) {
+      toggleMenu(nav, false);
+      nav.querySelector('.nav-hamburger button').focus();
+    }
+  }
+}
+
+/**
+ * Loads and decorates the HPE header block.
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
-  // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/content/nav';
   const fragment = await loadFragment(navPath);
 
-  // decorate nav DOM
   block.textContent = '';
   const nav = document.createElement('nav');
   nav.id = 'nav';
-  while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
+  nav.setAttribute('aria-expanded', 'false');
 
-  const classes = ['brand', 'sections', 'tools'];
+  if (fragment) {
+    while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
+  }
+
+  // Classify nav sections: brand, sections (links)
+  const classes = ['brand', 'sections'];
   classes.forEach((c, i) => {
     const section = nav.children[i];
     if (section) section.classList.add(`nav-${c}`);
   });
 
+  // Clean up brand link — remove EDS button decoration
   const navBrand = nav.querySelector('.nav-brand');
-  const brandLink = navBrand.querySelector('.button');
-  if (brandLink) {
-    brandLink.className = '';
-    brandLink.closest('.button-container').className = '';
-  }
-
-  const navSections = nav.querySelector('.nav-sections');
-  if (navSections) {
-    navSections.querySelectorAll(':scope .default-content-wrapper > ul > li').forEach((navSection) => {
-      if (navSection.querySelector('ul')) navSection.classList.add('nav-drop');
-      navSection.addEventListener('click', () => {
-        if (isDesktop.matches) {
-          const expanded = navSection.getAttribute('aria-expanded') === 'true';
-          toggleAllNavSections(navSections);
-          navSection.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-        }
-      });
-    });
-    navSections.querySelectorAll('.button-container').forEach((buttonContainer) => {
-      buttonContainer.classList.remove('button-container');
-      buttonContainer.querySelector('.button').classList.remove('button');
-    });
-  }
-
-  const navTools = nav.querySelector('.nav-tools');
-  if (navTools) {
-    const search = navTools.querySelector('a[href*="search"]');
-    if (search && search.textContent === '') {
-      search.setAttribute('aria-label', 'Search');
+  if (navBrand) {
+    const brandLink = navBrand.querySelector('.button');
+    if (brandLink) {
+      brandLink.className = '';
+      const btnParent = brandLink.closest('.button-container');
+      if (btnParent) btnParent.className = '';
     }
   }
 
-  // hamburger for mobile
+  // Clean up nav section links — remove EDS button decoration
+  const navSections = nav.querySelector('.nav-sections');
+  if (navSections) {
+    navSections.querySelectorAll('.button-container').forEach((bc) => {
+      bc.classList.remove('button-container');
+      const btn = bc.querySelector('.button');
+      if (btn) btn.classList.remove('button');
+    });
+  }
+
+  // Build utility nav (search + language)
+  const navTools = document.createElement('div');
+  navTools.classList.add('nav-tools');
+
+  // Search button
+  const searchBtn = document.createElement('button');
+  searchBtn.type = 'button';
+  searchBtn.className = 'nav-tools-search';
+  searchBtn.setAttribute('aria-label', 'Search');
+  const searchIcon = document.createElement('span');
+  searchIcon.className = 'icon icon-search';
+  searchBtn.append(searchIcon);
+  navTools.append(searchBtn);
+
+  // Language selector
+  const langLink = document.createElement('a');
+  langLink.href = '/us/en/home.html';
+  langLink.className = 'nav-tools-lang';
+  langLink.textContent = 'EN';
+  langLink.setAttribute('aria-label', 'Select language');
+  navTools.append(langLink);
+
+  nav.append(navTools);
+
+  // Hamburger for mobile
   const hamburger = document.createElement('div');
   hamburger.classList.add('nav-hamburger');
-  hamburger.innerHTML = `<button type="button" aria-controls="nav" aria-label="Open navigation">
-      <span class="nav-hamburger-icon"></span>
-    </button>`;
-  hamburger.addEventListener('click', () => toggleMenu(nav, navSections));
+  const hamburgerBtn = document.createElement('button');
+  hamburgerBtn.type = 'button';
+  hamburgerBtn.setAttribute('aria-controls', 'nav');
+  hamburgerBtn.setAttribute('aria-label', 'Open navigation');
+  const hamburgerIcon = document.createElement('span');
+  hamburgerIcon.className = 'nav-hamburger-icon';
+  hamburgerBtn.append(hamburgerIcon);
+  hamburger.append(hamburgerBtn);
+  hamburger.addEventListener('click', () => toggleMenu(nav));
   nav.prepend(hamburger);
-  nav.setAttribute('aria-expanded', 'false');
-  // prevent mobile nav behavior on window resize
-  toggleMenu(nav, navSections, isDesktop.matches);
-  isDesktop.addEventListener('change', () => toggleMenu(nav, navSections, isDesktop.matches));
+
+  // Set initial state
+  toggleMenu(nav, isDesktop.matches);
+  isDesktop.addEventListener('change', () => toggleMenu(nav, isDesktop.matches));
+  window.addEventListener('keydown', closeOnEscape);
 
   const navWrapper = document.createElement('div');
   navWrapper.className = 'nav-wrapper';
   navWrapper.append(nav);
   block.append(navWrapper);
-
-  if (getMetadata('breadcrumbs').toLowerCase() === 'true') {
-    navWrapper.append(await buildBreadcrumbs());
-  }
 }

--- a/content/footer.html
+++ b/content/footer.html
@@ -1,0 +1,83 @@
+<html>
+<body>
+  <header></header>
+  <main>
+    <div>
+      <p><a href="/"><img src="/icons/hpe-logo.svg" alt="Hewlett Packard Enterprise" width="180" height="40"></a></p>
+      <ul>
+        <li><a href="/us/en/buy-parts-products.html">How to buy</a></li>
+        <li><a href="https://support.hpe.com/connect/s/">Product support</a></li>
+        <li><a href="/us/en/contact/email-sales.html"><strong>Email sales</strong></a></li>
+        <li><a href="/us/en/contact.html"><strong>Contact us</strong></a></li>
+        <li><a href="/us/en/contact/chat.html"><strong>Chat with sales</strong></a></li>
+      </ul>
+      <p>Follow HPE on</p>
+      <ul>
+        <li><a href="https://www.linkedin.com/company/hewlett-packard-enterprise" title="LinkedIn"><span class="icon icon-linkedin"></span></a></li>
+        <li><a href="https://x.com/HPE" title="X"><span class="icon icon-x"></span></a></li>
+        <li><a href="https://www.instagram.com/hpe/" title="Instagram"><span class="icon icon-instagram"></span></a></li>
+        <li><a href="https://www.threads.net/@hpe" title="Threads"><span class="icon icon-threads"></span></a></li>
+        <li><a href="https://www.facebook.com/HewlettPackardEnterprise/" title="Facebook"><span class="icon icon-facebook"></span></a></li>
+        <li><a href="https://www.youtube.com/user/HewlettPackardVideos" title="YouTube"><span class="icon icon-youtube"></span></a></li>
+        <li><a href="https://www.hpe.com/us/en/newsroom/rss-feeds.html" title="RSS"><span class="icon icon-rss"></span></a></li>
+      </ul>
+    </div>
+    <div>
+      <h3>Company</h3>
+      <ul>
+        <li><a href="/us/en/about.html">About HPE</a></li>
+        <li><a href="/us/en/about/accessibility-aging.html">Accessibility</a></li>
+        <li><a href="https://careers.hpe.com/us/en">Careers</a></li>
+        <li><a href="/us/en/living-progress.html">Corporate responsibility</a></li>
+        <li><a href="/us/en/hpe-labs.html">HPE Labs</a></li>
+        <li><a href="https://investors.hpe.com/">Investor relations</a></li>
+        <li><a href="/us/en/leadership.html">Leadership</a></li>
+        <li><a href="/us/en/living-progress/political-engagement-advocacy.html">Public policy</a></li>
+      </ul>
+      <h3>Support</h3>
+      <ul>
+        <li><a href="/us/en/oem.html">OEM Solutions</a></li>
+        <li><a href="/us/en/about/environment/product-recycling.html">Product return and recycling</a></li>
+        <li><a href="https://support.hpe.com/hpesc/public/home">Product support</a></li>
+        <li><a href="https://myenterpriselicense.hpe.com/cwp-ui/auth/login">Software and drivers</a></li>
+        <li><a href="https://support.hpe.com/connect/s/warrantycheck">Warranty check</a></li>
+      </ul>
+      <h3>Events and news</h3>
+      <ul>
+        <li><a href="/us/en/events.html">Events</a></li>
+        <li><a href="/us/en/events/discover-events.html">HPE Discover</a></li>
+        <li><a href="/us/en/newsroom.html">Newsroom</a></li>
+      </ul>
+      <h3>Customer resources</h3>
+      <ul>
+        <li><a href="/us/en/contact-hpe.html">Contact Us</a></li>
+        <li><a href="/us/en/about/digital-trust-center.html">Digital Trust Center</a></li>
+        <li><a href="https://education.hpe.com/us/en/training/index.html">Education and training</a></li>
+        <li><a href="/us/en/what-is.html">Enterprise glossary</a></li>
+        <li><a href="/us/en/financing-asset-management-services.html">Financial services</a></li>
+        <li><a href="https://community.hpe.com/">HPE communities</a></li>
+        <li><a href="https://auth.hpe.com/">HPE sign in</a></li>
+      </ul>
+      <h3>Partners</h3>
+      <ul>
+        <li><a href="/us/en/alliance.html">Alliances</a></li>
+        <li><a href="https://certification-learning.hpe.com/tr/">Certifications</a></li>
+        <li><a href="https://partnerconnect.hpe.com/home">Find a partner</a></li>
+        <li><a href="/us/en/partners/partner-ready-vantage.html">Partner programs</a></li>
+      </ul>
+    </div>
+    <div>
+      <p>© Copyright 2026 Hewlett Packard Enterprise Development LP</p>
+      <ul>
+        <li><a href="/us/en/legal/privacy.html">Privacy</a></li>
+        <li><a href="/us/en/about/legal/terms-of-use.html">Terms of Use</a></li>
+        <li><a href="/us/en/legal/privacy.html#datacollection">Ad Choices &amp; Cookies</a></li>
+        <li><a href="/us/en/privacy/personal-information.html">Do not Sell my Personal Information</a></li>
+        <li><a href="/us/en/sitemap.html">Sitemap</a></li>
+      </ul>
+      <p><a href="/us/en/country-selector.html">United States (en)</a></p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+</html>

--- a/content/footer.plain.html
+++ b/content/footer.plain.html
@@ -1,0 +1,75 @@
+<div>
+  <p><a href="/"><img src="/icons/hpe-logo.svg" alt="Hewlett Packard Enterprise" width="180" height="40"></a></p>
+  <ul>
+    <li><a href="/us/en/buy-parts-products.html">How to buy</a></li>
+    <li><a href="https://support.hpe.com/connect/s/">Product support</a></li>
+    <li><a href="/us/en/contact/email-sales.html"><strong>Email sales</strong></a></li>
+    <li><a href="/us/en/contact.html"><strong>Contact us</strong></a></li>
+    <li><a href="/us/en/contact/chat.html"><strong>Chat with sales</strong></a></li>
+  </ul>
+  <p>Follow HPE on</p>
+  <ul>
+    <li><a href="https://www.linkedin.com/company/hewlett-packard-enterprise" title="LinkedIn"><span class="icon icon-linkedin"></span></a></li>
+    <li><a href="https://x.com/HPE" title="X"><span class="icon icon-x"></span></a></li>
+    <li><a href="https://www.instagram.com/hpe/" title="Instagram"><span class="icon icon-instagram"></span></a></li>
+    <li><a href="https://www.threads.net/@hpe" title="Threads"><span class="icon icon-threads"></span></a></li>
+    <li><a href="https://www.facebook.com/HewlettPackardEnterprise/" title="Facebook"><span class="icon icon-facebook"></span></a></li>
+    <li><a href="https://www.youtube.com/user/HewlettPackardVideos" title="YouTube"><span class="icon icon-youtube"></span></a></li>
+    <li><a href="https://www.hpe.com/us/en/newsroom/rss-feeds.html" title="RSS"><span class="icon icon-rss"></span></a></li>
+  </ul>
+</div>
+<div>
+  <h3>Company</h3>
+  <ul>
+    <li><a href="/us/en/about.html">About HPE</a></li>
+    <li><a href="/us/en/about/accessibility-aging.html">Accessibility</a></li>
+    <li><a href="https://careers.hpe.com/us/en">Careers</a></li>
+    <li><a href="/us/en/living-progress.html">Corporate responsibility</a></li>
+    <li><a href="/us/en/hpe-labs.html">HPE Labs</a></li>
+    <li><a href="https://investors.hpe.com/">Investor relations</a></li>
+    <li><a href="/us/en/leadership.html">Leadership</a></li>
+    <li><a href="/us/en/living-progress/political-engagement-advocacy.html">Public policy</a></li>
+  </ul>
+  <h3>Support</h3>
+  <ul>
+    <li><a href="/us/en/oem.html">OEM Solutions</a></li>
+    <li><a href="/us/en/about/environment/product-recycling.html">Product return and recycling</a></li>
+    <li><a href="https://support.hpe.com/hpesc/public/home">Product support</a></li>
+    <li><a href="https://myenterpriselicense.hpe.com/cwp-ui/auth/login">Software and drivers</a></li>
+    <li><a href="https://support.hpe.com/connect/s/warrantycheck">Warranty check</a></li>
+  </ul>
+  <h3>Events and news</h3>
+  <ul>
+    <li><a href="/us/en/events.html">Events</a></li>
+    <li><a href="/us/en/events/discover-events.html">HPE Discover</a></li>
+    <li><a href="/us/en/newsroom.html">Newsroom</a></li>
+  </ul>
+  <h3>Customer resources</h3>
+  <ul>
+    <li><a href="/us/en/contact-hpe.html">Contact Us</a></li>
+    <li><a href="/us/en/about/digital-trust-center.html">Digital Trust Center</a></li>
+    <li><a href="https://education.hpe.com/us/en/training/index.html">Education and training</a></li>
+    <li><a href="/us/en/what-is.html">Enterprise glossary</a></li>
+    <li><a href="/us/en/financing-asset-management-services.html">Financial services</a></li>
+    <li><a href="https://community.hpe.com/">HPE communities</a></li>
+    <li><a href="https://auth.hpe.com/">HPE sign in</a></li>
+  </ul>
+  <h3>Partners</h3>
+  <ul>
+    <li><a href="/us/en/alliance.html">Alliances</a></li>
+    <li><a href="https://certification-learning.hpe.com/tr/">Certifications</a></li>
+    <li><a href="https://partnerconnect.hpe.com/home">Find a partner</a></li>
+    <li><a href="/us/en/partners/partner-ready-vantage.html">Partner programs</a></li>
+  </ul>
+</div>
+<div>
+  <p>© Copyright 2026 Hewlett Packard Enterprise Development LP</p>
+  <ul>
+    <li><a href="/us/en/legal/privacy.html">Privacy</a></li>
+    <li><a href="/us/en/about/legal/terms-of-use.html">Terms of Use</a></li>
+    <li><a href="/us/en/legal/privacy.html#datacollection">Ad Choices &amp; Cookies</a></li>
+    <li><a href="/us/en/privacy/personal-information.html">Do not Sell my Personal Information</a></li>
+    <li><a href="/us/en/sitemap.html">Sitemap</a></li>
+  </ul>
+  <p><a href="/us/en/country-selector.html">United States (en)</a></p>
+</div>

--- a/content/index.html
+++ b/content/index.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>Hewlett Packard Enterprise (HPE)</title>
+  <meta name="description" content="HPE homepage - Adobe Summit demo">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="/scripts/scripts.js" type="module"></script>
+  <link rel="stylesheet" href="/styles/styles.css">
+</head>
+<body>
+  <header></header>
+  <main>
+    <div>
+      <h1>HPE Homepage</h1>
+      <p>Placeholder content — blocks will be added in later phases.</p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+</html>

--- a/content/nav.html
+++ b/content/nav.html
@@ -1,0 +1,19 @@
+<html>
+<body>
+  <header></header>
+  <main>
+    <div>
+      <p><a href="/" title="HPE"><img src="/icons/hpe-logo.svg" alt="Hewlett Packard Enterprise"></a></p>
+      <ul>
+        <li><a href="/us/en/greenlake.html">GreenLake</a></li>
+        <li><a href="/us/en/solutions.html">Solutions</a></li>
+        <li><a href="/us/en/products.html">Products</a></li>
+        <li><a href="/us/en/services.html">Services</a></li>
+        <li><a href="/us/en/support.html">Support</a></li>
+        <li><a href="/us/en/about.html">Company</a></li>
+      </ul>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+</html>

--- a/content/nav.plain.html
+++ b/content/nav.plain.html
@@ -1,0 +1,13 @@
+<div>
+  <p><a href="/" title="HPE"><img src="/icons/hpe-logo.svg" alt="Hewlett Packard Enterprise"></a></p>
+</div>
+<div>
+  <ul>
+    <li><a href="/us/en/greenlake.html">GreenLake</a></li>
+    <li><a href="/us/en/solutions.html">Solutions</a></li>
+    <li><a href="/us/en/products.html">Products</a></li>
+    <li><a href="/us/en/services.html">Services</a></li>
+    <li><a href="/us/en/support.html">Support</a></li>
+    <li><a href="/us/en/about.html">Company</a></li>
+  </ul>
+</div>

--- a/icons/hpe-logo.svg
+++ b/icons/hpe-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 216 36" fill="#01a982">
+  <path d="M46.7 0H36.1L24.8 14.6h10.6L46.7 0zM35 21.4H24.4L13.1 36h10.6L35 21.4zM23.3 14.6H12.7L1.4 29.2h10.6l11.3-14.6zM58.4 6.8H47.8L36.5 21.4h10.6L58.4 6.8z"/>
+  <text x="68" y="26" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#01a982">Hewlett Packard Enterprise</text>
+</svg>


### PR DESCRIPTION
## Summary

Implements the two global components for the HPE homepage pixel-perfect demo: the header navigation bar and the multi-section footer.

### Header Block
- Dark nav bar (`#1D1F27`) at 80px height with fixed/sticky positioning
- HPE logo (SVG) left-aligned, links to homepage
- 6 primary nav items: GreenLake, Solutions, Products, Services, Support, Company
- Pill-shaped hover states matching original (100px border-radius, `rgb(212,212,212)` text)
- Search icon button + "EN" language selector (right side)
- Mobile: hamburger menu with full-height slide-down overlay, Escape key to close

### Footer Block
- Dark background matching header color
- **Top bar:** HPE logo + action links (How to buy, Product support) + pill-button CTAs (Email sales, Contact us, Chat with sales) + "Follow HPE on" social icons (LinkedIn, X, Instagram, Threads, Facebook, YouTube, RSS)
- **Nav columns:** 5-column layout on desktop (Company, Support, Events & news, Customer resources, Partners) with accordion expand/collapse on mobile
- **Copyright bar:** © 2026 text + legal links (Privacy, Terms, Ad Choices, Do Not Sell, Sitemap) + "United States (en)" language selector

### Content Files
- `content/nav.plain.html` — Header navigation fragment
- `content/footer.plain.html` — Footer fragment with all links
- `content/index.html` — Placeholder homepage with EDS script loading
- `icons/hpe-logo.svg` — HPE brand logo

### Verification
- [x] Header renders with dark background, logo, nav links at 1440px
- [x] Footer renders all 3 sections (top bar, nav columns, copyright)
- [x] Stylelint passes clean
- [x] ESLint passes (0 errors, 1 pre-existing false-positive warning)
- [x] HPEGraphik font loads correctly

### Known Polish Items (for Phase 6 QA)
- Logo SVG text gets clipped at narrow widths — needs wider viewBox
- Social media icon SVGs need to be added to `/icons/`
- Search icon SVG needs to be added

## Related Issues

Closes #3, closes #4

## Test URLs

- **Before:** https://main--summit-hpp--aemdemos.aem.page/
- **After:** https://phase1-dev--summit-hpp--aemdemos.aem.page/content/

🤖 Generated with [Claude Code](https://claude.com/claude-code)