### PR TITLE
feat: Phase 5 — Products & Services sections

### DIFF
--- a/blocks/product-cards/product-cards.css
+++ b/blocks/product-cards/product-cards.css
@@ -1,0 +1,123 @@
+/* Product Cards — grid of product category cards */
+
+main .product-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-m);
+  padding: 0;
+}
+
+/* Card */
+main .product-cards .product-card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--background-color);
+  border: 1px solid var(--border-light-color);
+  border-radius: 8px;
+  overflow: hidden;
+  transition: box-shadow var(--transition-slow);
+}
+
+main .product-cards .product-card:hover {
+  box-shadow: var(--shadow-lg);
+}
+
+/* Card image */
+main .product-cards .product-card-image {
+  width: 100%;
+  overflow: hidden;
+}
+
+main .product-cards .product-card-image picture {
+  display: block;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+}
+
+main .product-cards .product-card-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Card content */
+main .product-cards .product-card-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: var(--spacing-m);
+  gap: var(--spacing-s);
+}
+
+main .product-cards .product-card-content h3 {
+  font-size: var(--heading-font-size-l);
+  font-weight: 500;
+  color: var(--text-color);
+  margin: 0;
+}
+
+main .product-cards .product-card-content p {
+  color: var(--text-secondary-color);
+  font-size: var(--body-font-size-s);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* CTA link */
+main .product-cards .product-card-cta {
+  margin-top: auto;
+  padding-top: var(--spacing-s);
+}
+
+main .product-cards .product-card-link {
+  color: var(--color-hpe-green);
+  font-size: var(--body-font-size-s);
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  transition: color var(--transition-base);
+}
+
+main .product-cards .product-card-link::after {
+  content: '\2192';
+  font-size: 1.1em;
+  transition: transform var(--transition-base);
+}
+
+main .product-cards .product-card-link:hover {
+  color: var(--color-hpe-green-hover);
+  text-decoration: none;
+}
+
+main .product-cards .product-card-link:hover::after {
+  transform: translateX(4px);
+}
+
+/* Tablet: 2 columns for two-up, 2 columns for three-up */
+@media (width >= 600px) {
+  main .product-cards.two-up {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  main .product-cards.three-up {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Desktop: 2 columns for two-up, 3 columns for three-up */
+@media (width >= 900px) {
+  main .product-cards.two-up {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  main .product-cards.three-up {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  main .product-cards .product-card-content {
+    padding: var(--spacing-l);
+  }
+}

--- a/blocks/product-cards/product-cards.js
+++ b/blocks/product-cards/product-cards.js
@@ -1,0 +1,38 @@
+/**
+ * Decorates the product-cards block.
+ * Each row contains one card with an image cell and a content cell.
+ * @param {Element} block The product-cards block element
+ */
+export default async function decorate(block) {
+  const rows = [...block.children];
+
+  rows.forEach((row) => {
+    row.classList.add('product-card');
+
+    const [imageCell, contentCell] = [...row.children];
+
+    if (imageCell) {
+      imageCell.classList.add('product-card-image');
+      const img = imageCell.querySelector('img');
+      if (img) {
+        img.setAttribute('loading', 'lazy');
+      }
+    }
+
+    if (contentCell) {
+      contentCell.classList.add('product-card-content');
+
+      // Find the last paragraph containing a link — treat it as the CTA
+      const paragraphs = [...contentCell.querySelectorAll('p')];
+      const ctaParagraph = [...paragraphs].reverse().find((p) => p.querySelector('a') && !p.querySelector('picture'));
+
+      if (ctaParagraph) {
+        ctaParagraph.classList.add('product-card-cta');
+        const ctaLink = ctaParagraph.querySelector('a');
+        if (ctaLink) {
+          ctaLink.classList.add('product-card-link');
+        }
+      }
+    }
+  });
+}

--- a/blocks/section-header/section-header.css
+++ b/blocks/section-header/section-header.css
@@ -1,0 +1,46 @@
+/* Section Header — centered heading with description text */
+
+main .section-header {
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+  padding-bottom: var(--spacing-xl);
+}
+
+main .section-header h2 {
+  margin-bottom: var(--spacing-s);
+}
+
+main .section-header p {
+  color: var(--text-secondary-color);
+  font-size: var(--body-font-size-m);
+  line-height: 1.5;
+  margin-bottom: var(--spacing-s);
+}
+
+main .section-header p:last-child {
+  margin-bottom: 0;
+}
+
+/* Inline links within paragraphs */
+main .section-header a {
+  color: var(--color-hpe-green);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+main .section-header a:hover {
+  color: var(--color-hpe-green-hover);
+  text-decoration: underline;
+}
+
+@media (width >= 900px) {
+  main .section-header {
+    max-width: 900px;
+    padding-bottom: var(--spacing-xxl);
+  }
+
+  main .section-header h2 {
+    margin-bottom: var(--spacing-m);
+  }
+}

--- a/blocks/section-header/section-header.js
+++ b/blocks/section-header/section-header.js
@@ -1,0 +1,20 @@
+/**
+ * Section Header block — simple heading + description text.
+ * Strips EDS auto-button styling from inline links so they render as plain text links.
+ * @param {Element} block The section-header block element
+ */
+export default function decorate(block) {
+  // Remove button classes from inline links so they stay as plain text links
+  block.querySelectorAll('a.button').forEach((link) => {
+    link.classList.remove('button', 'primary', 'secondary');
+    const wrapper = link.closest('.button-container');
+    if (wrapper) {
+      // Unwrap: move children out and remove the button-container wrapper
+      const parent = wrapper.parentElement;
+      while (wrapper.firstChild) {
+        parent.insertBefore(wrapper.firstChild, wrapper);
+      }
+      wrapper.remove();
+    }
+  });
+}

--- a/content/index.html
+++ b/content/index.html
@@ -273,6 +273,89 @@
       </div>
     </div>
 
+    <!-- Products: Section Header -->
+    <div>
+      <div class="section-header">
+        <div>
+          <div>
+            <h2>Products</h2>
+            <p>Power your edge-to-cloud platform with proven, transformative, and innovative IT products, solutions, and services.</p>
+            <p>Lease and financing available through <a href="https://www.hpe.com/us/en/financing-asset-management-services.html">HPE Financial Services</a>.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Products: Two-up (Networking + Software) -->
+    <div>
+      <div class="product-cards two-up">
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/landmark/products/homepage-products-juniper.jpg" alt="Networking"></picture></div>
+          <div>
+            <h3>Networking</h3>
+            <p>Capture, secure and transport data to users and applications from edge to cloud with HPE Networking products.</p>
+            <p><a href="https://www.hpe.com/us/en/networking.html">Explore HPE Networking</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/landmark/products/homepage-products-software.jpg" alt="Software"></picture></div>
+          <div>
+            <h3>Software</h3>
+            <p>Enable successful outcomes, boost productivity, and unlock the value and insights from data across edge to cloud with HPE software.</p>
+            <p><a href="https://www.hpe.com/us/en/software.html">Explore HPE Software</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Products: Three-up (Storage + Compute + Supercomputing) -->
+    <div>
+      <div class="product-cards three-up">
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/landmark/products/Storage-gray-bkg-512x332.jpg" alt="Storage"></picture></div>
+          <div>
+            <h3>Storage</h3>
+            <p>Accelerate data-first modernization with HPE storage products to radically simplify data management with the industry's most comprehensive solutions to store, manage, and protect data across hybrid cloud.</p>
+            <p><a href="https://www.hpe.com/us/en/storage.html">Explore HPE Storage</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/landmark/products/homepage-products-compute.jpg" alt="Compute"></picture></div>
+          <div>
+            <h3>Compute</h3>
+            <p>Accelerate innovation from edge to cloud with workload-optimized compute for today's data-first, hybrid world.</p>
+            <p><a href="https://www.hpe.com/us/en/compute.html">Explore HPE Compute</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/landmark/products/Supercomputing-gray-bkg-784x332.jpg" alt="Supercomputing"></picture></div>
+          <div>
+            <h3>Supercomputing</h3>
+            <p>Empower world-changing innovation and discovery in the Exascale era and beyond, with faster time-to-results and accelerated AI with supercomputing products.</p>
+            <p><a href="https://www.hpe.com/us/en/supercomputing.html">Explore HPE Supercomputing</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Services Banner -->
+    <div>
+      <div class="section-metadata">
+        <div><div>style</div><div>dark-alt</div></div>
+      </div>
+      <div class="feature-banner">
+        <div>
+          <div>
+            <h2>HPE Services</h2>
+            <p>HPE Services experts can help you from planning to operating and beyond, so you can accelerate edge to cloud transformation, optimize operations, and maximize IT investments.</p>
+          </div>
+          <div>
+            <p><a href="https://www.hpe.com/us/en/services.html">Explore HPE Services</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </main>
   <footer></footer>
 </body>


### PR DESCRIPTION
## Summary
- **Section Header block** — centered heading with description text, strips EDS auto-button styling from inline links (e.g., "HPE Financial Services")
- **Product Cards block** — CSS grid with `two-up` (2-col) and `three-up` (3-col) variants, card hover shadow lift, green CTA links with animated arrow
- **Services Banner** — reuses existing `feature-banner` block in `dark-alt` section for "HPE Services" content
- Adds all Products & Services section content to homepage

Closes #12, Closes #13

## Test plan
- [ ] Verify section-header renders "Products" heading with inline link at localhost:3000
- [ ] Verify product-cards two-up shows Networking + Software in 2-column grid
- [ ] Verify product-cards three-up shows Storage + Compute + Supercomputing in 3-column grid
- [ ] Verify cards have hover shadow effect and CTA arrow animation
- [ ] Verify services banner renders with dark-alt background
- [ ] Confirm `npm run lint` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)