### PR TITLE
fix: Phase 6 — Visual QA, metadata, performance

### DIFF
--- a/blocks/greenlake-promo/greenlake-promo.js
+++ b/blocks/greenlake-promo/greenlake-promo.js
@@ -24,8 +24,14 @@ export default async function decorate(block) {
   if (leftPictures.length > 0) {
     const logoWrap = document.createElement('div');
     logoWrap.classList.add('greenlake-promo-logo');
-    leftPictures[0].parentElement.replaceWith(logoWrap);
-    logoWrap.appendChild(leftPictures[0]);
+    const logoPicParent = leftPictures[0].parentElement;
+    if (logoPicParent === leftCell) {
+      leftCell.insertBefore(logoWrap, leftPictures[0]);
+      logoWrap.appendChild(leftPictures[0]);
+    } else {
+      logoPicParent.replaceWith(logoWrap);
+      logoWrap.appendChild(leftPictures[0]);
+    }
   }
 
   // Find the description paragraph (the one with substantial text, not just a picture)
@@ -81,26 +87,36 @@ export default async function decorate(block) {
   // --- Right Panel ---
   rightCell.classList.add('greenlake-promo-right');
 
+  // Collect elements before any DOM mutations
   const rightPicture = rightCell.querySelector('picture');
+  const heading = rightCell.querySelector('h3');
+  const ctaLink = rightCell.querySelector('a');
+  const ctaWrap = ctaLink ? ctaLink.closest('p') : null;
+
+  // Clear and rebuild the right panel
+  rightCell.innerHTML = '';
+
   if (rightPicture) {
     const screenshotWrap = document.createElement('div');
     screenshotWrap.classList.add('greenlake-promo-screenshot');
-    rightPicture.parentElement.replaceWith(screenshotWrap);
     screenshotWrap.appendChild(rightPicture);
+    rightCell.appendChild(screenshotWrap);
   }
 
-  const heading = rightCell.querySelector('h3');
   if (heading) {
     heading.classList.add('greenlake-promo-heading');
+    rightCell.appendChild(heading);
   }
 
-  // CTA link -> button
-  const ctaLink = rightCell.querySelector('a');
-  if (ctaLink) {
+  if (ctaWrap) {
+    ctaWrap.classList.add('greenlake-promo-cta');
+    if (ctaLink) ctaLink.classList.add('button');
+    rightCell.appendChild(ctaWrap);
+  } else if (ctaLink) {
     ctaLink.classList.add('button');
-    const ctaWrap = ctaLink.closest('p');
-    if (ctaWrap) {
-      ctaWrap.classList.add('greenlake-promo-cta');
-    }
+    const p = document.createElement('p');
+    p.classList.add('greenlake-promo-cta');
+    p.appendChild(ctaLink);
+    rightCell.appendChild(p);
   }
 }

--- a/content/index.html
+++ b/content/index.html
@@ -1,8 +1,15 @@
 <html>
 <head>
   <title>Hewlett Packard Enterprise (HPE)</title>
-  <meta name="description" content="HPE homepage - Adobe Summit demo">
+  <meta name="description" content="HPE is a leader in essential enterprise technology, bringing together the power of AI, cloud, and networking to help organizations unlock their boldest ambitions.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="keywords" content="Hewlett Packard Enterprise, HPE, HPE home page, HP Enterprise">
+  <meta name="robots" content="follow, index">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Hewlett Packard Enterprise">
+  <meta property="og:description" content="HPE is a leader in essential enterprise technology, bringing together the power of AI, cloud, and networking to help organizations unlock their boldest ambitions.">
+  <meta property="og:image" content="https://www.hpe.com/content/dam/hpe/social/logo.jpg">
+  <meta property="og:url" content="https://www.hpe.com/us/en/home.html">
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css">
 </head>


### PR DESCRIPTION
## Summary
- **Metadata**: Added full Open Graph tags (og:title, og:description, og:image, og:url) and improved meta description to match original HPE homepage
- **GreenLake promo fix**: Fixed right panel losing H3 heading ("Hybrid cloud, simplified") and CTA link during DOM decoration — elements are now collected before any mutations
- **Visual QA**: Verified all 11 homepage sections render correctly at 1440px desktop — correct backgrounds, typography, section order, and content
- **Performance**: Confirmed LCP image is `eager`, below-fold images get `lazy` loading via EDS, no CLS issues (all images have aspect-ratio constraints)

Closes #14, Closes #15, Closes #16

## Test plan
- [ ] Verify all 11 sections render at localhost:3000 with correct content
- [ ] Verify GreenLake promo shows screenshot, "Hybrid cloud, simplified" heading, and "Visit GreenLake" CTA
- [ ] Verify page metadata (view source) includes og:title, og:description, og:image
- [ ] Confirm `npm run lint` passes with no errors
- [ ] Verify hero image loads eagerly (LCP optimization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)