### PR TITLE
feat: Phase 8 — Missing content (news, hero, KDDI images)

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -28,6 +28,16 @@
             <p><a href="https://www.hpe.com/us/en/newsroom/press-release/2026/03/hpe-introduces-sweeping-security-advancements-to-secure-ai-adoption-and-strengthen-enterprise-resiliency.html">Read the press release</a></p>
           </div>
         </div>
+        <div>
+          <div>
+            <picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/landmark/marquee/inter-miami-homepage-marquee.jpg" alt="Inter Miami CF dreams big with Freedom Park"></picture>
+          </div>
+          <div>
+            <h1>Inter Miami CF dreams big with Freedom Park</h1>
+            <p>HPE technology brings Nu Stadium to life as Inter Miami CF opens its next chapter</p>
+            <p><a href="https://www.hpe.com/psnow/doc/a50015056enw?jumpid=in_pdfviewer-psnow">Read the story</a></p>
+          </div>
+        </div>
       </div>
     </div>
     <div>
@@ -69,6 +79,46 @@
           <div>
             <h6>HPE Alletra Storage MP X10000 becomes first NVIDIA-Certified Storage platform for enterprise AI</h6>
             <p><a href="https://www.hpe.com/us/en/newsroom/blog-post/2026/03/hpe-alletra-storage-mp-x10000-becomes-first-nvidia-certified-storage-object-based-platform-for-enterprise-ai.html">View the blog</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/generic-named/m-o/News-Tile-threat-labs-03-2026.jpg" alt="HPE Threat Labs report"></picture></div>
+          <div>
+            <h6>HPE Threat Labs report</h6>
+            <p>New HPE Threat Labs research finds organized cybercrime scaling enterprise-style attacks on critical sectors.</p>
+            <p><a href="https://www.hpe.com/us/en/newsroom/press-release/2026/03/hpe-threat-labs-report-reveals-cyber-adversaries-are-morphing-their-business-model-to-scale-and-accelerate-attacks.html">View the press release</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/generic-named/m-o/News-Tile-Q1-results-03-2026.jpg" alt="HPE reports fiscal 2026 first quarter results"></picture></div>
+          <div>
+            <h6>HPE reports fiscal 2026 first quarter results</h6>
+            <p>Strong Networking and increased Cloud &amp; AI profitability in Q1 drive higher FY26 outlook</p>
+            <p><a href="https://www.hpe.com/us/en/newsroom/press-release/2026/03/hpe-reports-fiscal-2026-first-quarter-results.html">View the press release</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/generic-named/m-o/News-Tile-MWC-02-2026.jpg" alt="HPE accelerates service provider modernization at MWC"></picture></div>
+          <div>
+            <h6>HPE accelerates service provider modernization at MWC</h6>
+            <p>Integrated telco portfolio helps HPE customers capitalize on high growth AI opportunities</p>
+            <p><a href="https://www.hpe.com/us/en/newsroom/press-release/2026/02/hpe-accelerates-service-provider-modernization-with-ai-infrastructure-innovations-at-mwc-2026.html">View the press release</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/generic-named/m-o/News-Tile-SAP-IDC-03-2026.jpg" alt="IDC MarketScape: SAP HANA-Certified Server Appliances 2026"></picture></div>
+          <div>
+            <h6>IDC MarketScape: Worldwide SAP HANA-Certified Server Appliances 2026 Vendor Assessment</h6>
+            <p>HPE is a Leader in the IDC MarketScape: Worldwide SAP HANA-Certified Server Appliances 2026 Vendor Assessment</p>
+            <p><a href="https://www.hpe.com/us/en/newsroom/blog-post/2026/03/hpe-is-a-leader-for-sap-certified-servers-according-to-the-idc-marketscape-report.html">View the blog</a></p>
+          </div>
+        </div>
+        <div>
+          <div><picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/generic-named/m-o/News-Tile-virtualization-02-2026.jpg" alt="Only 5% of enterprises are fully ready for a virtualization reset"></picture></div>
+          <div>
+            <h6>Only 5% of enterprises are fully ready for a virtualization reset</h6>
+            <p>HPE research shows more than two thirds of enterprises plan to virtualize for AI readiness, highlighting a significant gap in execution.</p>
+            <p><a href="https://www.hpe.com/us/en/newsroom/press-release/2026/02/new-research-finds-only-5-of-enterprises-are-fully-ready-for-the-great-virtualization-reset.html">Read the report</a></p>
           </div>
         </div>
         <div><div><p><a href="https://www.hpe.com/us/en/newsroom.html">Explore more news</a></p></div></div>
@@ -235,18 +285,23 @@
             <h3>Democratizing AI across Japan and the world</h3>
             <p>KDDI forges high-value partnerships to deliver powerful new AI data centers that create value and transformation on a global level</p>
             <p><strong>Watch the video</strong></p>
+            <picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/customer-stories/kddi-unlock-potential.jpg" alt="Unlock potential"></picture>
             <h3>Objectives</h3>
             <p>Leverage AI and cutting-edge infrastructure to reshape global connectivity and tackle Japan's social challenges</p>
+            <picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/customer-stories/kddi-people-crossing.jpg" alt="Image of people crossing the street"></picture>
             <h3>Outcomes</h3>
             <ul>
               <li>Enables democratization of AI with powerful infrastructure</li>
               <li>Optimizes use of technology, knowledge, and infrastructure through partnerships</li>
               <li>Uses advanced infrastructure which meets key business, social, and sustainability requirements</li>
             </ul>
+            <picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/customer-stories/kddi-logo.jpg" alt="KDDI"></picture>
             <h4>Generative AI is totally changing industries, how we work, and even how we think. But that needs to be supported by a specific and powerful infrastructure.</h4>
             <p>— Toru Maruta, Executive Officer for Technology Strategy and Planning, KDDI Corporation</p>
+            <picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/customer-stories/kddi-businessman-portrait.jpg" alt="Portrait of a businessman having an interview"></picture>
             <h3>Solution</h3>
             <ul><li>NVIDIA® GB200 NVL72 by HPE</li></ul>
+            <picture><img src="https://www.hpe.com/content/dam/hpe/shared-publishing/images-norend/homepage/customer-stories/kddi-woman-engineer.jpg" alt="Image of a woman engineer"></picture>
           </div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- **5 missing news carousel items** (#29): Added HPE Threat Labs report, Q1 fiscal results, MWC modernization, SAP IDC MarketScape, and Virtualization reset research. News carousel now matches source with 10 items.
- **Second hero carousel slide** (#31): Added Inter Miami CF / Freedom Park slide with image, H1, description, and CTA.
- **5 KDDI customer story images** (#30): Added images interspersed in the KDDI tab panel content (unlock potential, crossing street, KDDI logo, portrait, woman engineer).

Closes #29, Closes #30, Closes #31

## Test plan
- [ ] Verify news carousel shows 10 items with scroll at localhost:3000
- [ ] Verify hero carousel has 2 slides
- [ ] Verify KDDI tab panel has images between text sections
- [ ] Confirm `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)