### PR TITLE
fix: Phase A — Hero carousel structural rewrite

### DIFF
--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -1,6 +1,6 @@
-/* Hero Carousel — full-bleed hero matching HPE source exactly */
+/* Hero Carousel — structural match to HPE source */
 
-/* Break out of ALL constraints — true edge-to-edge */
+/* ===== CONTAINER: break out of all EDS constraints ===== */
 main .hero-carousel-container {
   max-width: unset;
   padding: 0;
@@ -14,19 +14,27 @@ main .hero-carousel-container > .hero-carousel-wrapper {
 main .hero-carousel {
   position: relative;
   width: 100%;
+  overflow: visible; /* source: overflow visible — nav extends below */
+}
+
+/* ===== SLIDES CONTAINER ===== */
+main .hero-carousel .hero-carousel-slides {
+  position: relative;
+  width: 100%;
   overflow: hidden;
 }
 
-/* Slide — hidden by default, shown when active */
+/* ===== SLIDE: flex-row with absolute image + relative content ===== */
 main .hero-carousel .hero-carousel-slide {
   position: absolute;
   inset: 0;
   display: flex;
-  flex-direction: column;
-  min-height: 420px;
+  flex-direction: row;
+  overflow: hidden;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.8s ease-in-out, visibility 0.8s;
+  height: 420px;
 }
 
 main .hero-carousel .hero-carousel-slide.active {
@@ -35,49 +43,30 @@ main .hero-carousel .hero-carousel-slide.active {
   visibility: visible;
 }
 
-/* Background image — full bleed edge-to-edge */
-main .hero-carousel .hero-carousel-bg {
+/* ===== IMAGE: position absolute, covers entire slide ===== */
+main .hero-carousel .hero-carousel-bg-img {
   position: absolute;
   inset: 0;
-  z-index: 0;
-}
-
-main .hero-carousel .hero-carousel-bg picture {
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
-main .hero-carousel .hero-carousel-bg img {
-  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: 50% 50%;
+  z-index: 0;
 }
 
-/* NO gradient overlay — source uses dark text on naturally light image areas */
-
-/* Content overlay */
+/* ===== CONTENT: relative flex-child, text on left ===== */
 main .hero-carousel .hero-carousel-content {
   position: relative;
   z-index: 1;
   display: flex;
-  align-items: flex-end;
-  flex: 1;
-  padding: 40px 24px 48px;
-}
-
-/* Constrained inner container — content starts at ~64px from left edge */
-main .hero-carousel .hero-carousel-content-inner {
-  position: relative;
-  z-index: 2;
+  flex-direction: column;
+  justify-content: center;
+  padding: 40px 24px 60px;
   width: 100%;
-  max-width: 1312px;
-  margin: 0 auto;
-  padding: 0;
+  max-width: 720px;
 }
 
-/* Heading — dark color, uppercase, condensed feel */
+/* H1: dark text, uppercase, condensed */
 main .hero-carousel .hero-carousel-content h1 {
   color: var(--dark-color);
   font-size: 36px;
@@ -85,27 +74,27 @@ main .hero-carousel .hero-carousel-content h1 {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   line-height: 1;
-  max-width: 600px;
-  margin-bottom: 16px;
+  margin: 0 0 16px;
 }
 
-/* Description — dark text */
+/* Description: muted dark text */
 main .hero-carousel .hero-carousel-content p {
   color: var(--text-secondary-color);
   font-size: 16px;
   line-height: 1.45;
-  max-width: 480px;
-  margin-bottom: 12px;
+  margin: 0 0 12px;
+  max-width: 540px;
 }
 
-/* CTA button — dark bg, pill shape, with arrow */
+/* CTA: dark pill button with arrow */
 main .hero-carousel .hero-carousel-cta {
-  margin-top: 20px;
+  margin-top: 16px;
 }
 
 main .hero-carousel .hero-carousel-cta a.button {
   background-color: var(--dark-color);
   color: white;
+  border: none;
   border-radius: 100px;
   padding: 14px 28px;
   font-size: 18px;
@@ -113,15 +102,8 @@ main .hero-carousel .hero-carousel-cta a.button {
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   transition: background-color 0.2s;
-  border: none;
-}
-
-main .hero-carousel .hero-carousel-cta a.button::after {
-  content: '\2192';
-  font-size: 1.2em;
-  transition: transform 0.2s;
 }
 
 main .hero-carousel .hero-carousel-cta a.button:hover {
@@ -129,17 +111,29 @@ main .hero-carousel .hero-carousel-cta a.button:hover {
   text-decoration: none;
 }
 
-main .hero-carousel .hero-carousel-cta a.button:hover::after {
+/* Arrow icon inside button */
+main .hero-carousel .hero-carousel-arrow {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  transition: transform 0.2s;
+}
+
+main .hero-carousel .hero-carousel-cta a.button:hover .hero-carousel-arrow {
   transform: translateX(4px);
 }
 
-/* ===== Navigation Arrows — bottom-left, below image, dark gray circles ===== */
+/* ===== NAV ARROWS: absolute, bottom-left, inside carousel ===== */
 main .hero-carousel .hero-carousel-nav {
-  position: relative;
+  position: absolute;
+  bottom: 0;
+  left: 24px;
   z-index: 10;
   display: flex;
   gap: 12px;
-  padding: 16px 24px;
+  padding: 16px 0;
+  transform: translateY(100%);
 }
 
 main .hero-carousel .hero-carousel-prev,
@@ -162,34 +156,32 @@ main .hero-carousel .hero-carousel-next:hover {
   background: rgb(65 72 80);
 }
 
-main .hero-carousel .hero-carousel-prev::after {
-  content: '';
-  display: block;
-  width: 9px;
-  height: 9px;
-  border-left: 2px solid white;
-  border-bottom: 2px solid white;
-  transform: rotate(45deg) translate(2px, -2px);
-}
-
+/* Chevron arrows via SVG background */
+main .hero-carousel .hero-carousel-prev::after,
 main .hero-carousel .hero-carousel-next::after {
   content: '';
   display: block;
-  width: 9px;
-  height: 9px;
-  border-right: 2px solid white;
-  border-top: 2px solid white;
-  transform: rotate(45deg) translate(-2px, 2px);
+  width: 16px;
+  height: 16px;
 }
 
-/* ===== Tablet (600px+) ===== */
+main .hero-carousel .hero-carousel-prev::after {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M15 19l-7-7 7-7'/%3E%3C/svg%3E") center/contain no-repeat;
+}
+
+main .hero-carousel .hero-carousel-next::after {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='white' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/%3E%3C/svg%3E") center/contain no-repeat;
+}
+
+/* ===== TABLET (600px+) ===== */
 @media (width >= 600px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 480px;
+    height: 500px;
   }
 
   main .hero-carousel .hero-carousel-content {
-    padding: 48px 40px 56px;
+    padding: 48px 40px 72px;
+    max-width: 660px;
   }
 
   main .hero-carousel .hero-carousel-content h1 {
@@ -199,50 +191,46 @@ main .hero-carousel .hero-carousel-next::after {
 
   main .hero-carousel .hero-carousel-cta a.button {
     font-size: 20px;
-    padding: 14px 28px;
   }
 
   main .hero-carousel .hero-carousel-nav {
-    padding: 16px 40px;
+    left: 40px;
   }
 }
 
-/* ===== Desktop (900px+) ===== */
+/* ===== DESKTOP (900px+) ===== */
 @media (width >= 900px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 580px;
+    height: 580px;
   }
 
   main .hero-carousel .hero-carousel-content {
-    padding: 60px 64px 80px;
-    align-items: center;
-  }
-
-  main .hero-carousel .hero-carousel-content-inner {
-    max-width: unset;
+    padding: 60px 0 96px;
+    margin-left: 64px;
+    max-width: 656px;
   }
 
   main .hero-carousel .hero-carousel-content h1 {
     font-size: 80px;
+    font-weight: 700;
     letter-spacing: 1.6px;
     line-height: 80px;
-    max-width: 660px;
   }
 
   main .hero-carousel .hero-carousel-content p {
     font-size: 18px;
     line-height: 26px;
-    max-width: 540px;
   }
 
   main .hero-carousel .hero-carousel-nav {
-    padding: 20px 64px;
+    left: 64px;
+    padding: 32px 0 29px;
   }
 }
 
-/* ===== Wide (1200px+) ===== */
+/* ===== WIDE (1200px+) ===== */
 @media (width >= 1200px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 648px;
+    height: 648px;
   }
 }

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -12,12 +12,22 @@ main .hero-carousel {
   overflow: hidden;
 }
 
-/* Slide */
+/* Slide — hidden by default, shown when active */
 main .hero-carousel .hero-carousel-slide {
-  position: relative;
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   min-height: 360px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.8s ease-in-out, visibility 0.8s;
+}
+
+main .hero-carousel .hero-carousel-slide.active {
+  position: relative;
+  opacity: 1;
+  visibility: visible;
 }
 
 /* Background image */
@@ -113,6 +123,88 @@ main .hero-carousel .hero-carousel-cta a.button:hover {
   text-decoration: none;
 }
 
+/* ===== Navigation Arrows ===== */
+main .hero-carousel .hero-carousel-nav {
+  position: absolute;
+  bottom: var(--spacing-m);
+  right: var(--spacing-m);
+  z-index: 10;
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+main .hero-carousel .hero-carousel-prev,
+main .hero-carousel .hero-carousel-next {
+  width: 40px;
+  height: 40px;
+  border: 2px solid rgb(255 255 255 / 60%);
+  border-radius: 50%;
+  background: rgb(0 0 0 / 30%);
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+main .hero-carousel .hero-carousel-prev:hover,
+main .hero-carousel .hero-carousel-next:hover {
+  background: rgb(0 0 0 / 60%);
+  border-color: white;
+}
+
+main .hero-carousel .hero-carousel-prev::after {
+  content: '';
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-left: 2px solid white;
+  border-bottom: 2px solid white;
+  transform: rotate(45deg) translate(2px, -2px);
+}
+
+main .hero-carousel .hero-carousel-next::after {
+  content: '';
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid white;
+  border-top: 2px solid white;
+  transform: rotate(45deg) translate(-2px, 2px);
+}
+
+/* ===== Dot Indicators ===== */
+main .hero-carousel .hero-carousel-dots {
+  position: absolute;
+  bottom: var(--spacing-m);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  gap: 8px;
+}
+
+main .hero-carousel .hero-carousel-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgb(255 255 255 / 60%);
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+main .hero-carousel .hero-carousel-dot.active {
+  background: white;
+  border-color: white;
+}
+
+main .hero-carousel .hero-carousel-dot:hover {
+  border-color: white;
+}
+
 /* ===== Tablet (600px+) ===== */
 @media (width >= 600px) {
   main .hero-carousel .hero-carousel-slide {
@@ -125,6 +217,11 @@ main .hero-carousel .hero-carousel-cta a.button:hover {
 
   main .hero-carousel .hero-carousel-content-inner {
     padding: 0 var(--spacing-l);
+  }
+
+  main .hero-carousel .hero-carousel-nav {
+    bottom: var(--spacing-l);
+    right: var(--spacing-l);
   }
 }
 
@@ -140,6 +237,12 @@ main .hero-carousel .hero-carousel-cta a.button:hover {
 
   main .hero-carousel .hero-carousel-content-inner {
     padding: 0 var(--spacing-l);
+  }
+
+  main .hero-carousel .hero-carousel-prev,
+  main .hero-carousel .hero-carousel-next {
+    width: 48px;
+    height: 48px;
   }
 }
 

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -18,7 +18,7 @@ main .hero-carousel .hero-carousel-slide {
   inset: 0;
   display: flex;
   flex-direction: column;
-  min-height: 360px;
+  min-height: 420px;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.8s ease-in-out, visibility 0.8s;
@@ -30,7 +30,7 @@ main .hero-carousel .hero-carousel-slide.active {
   visibility: visible;
 }
 
-/* Background image */
+/* Background image — full bleed, cover */
 main .hero-carousel .hero-carousel-bg {
   position: absolute;
   inset: 0;
@@ -58,9 +58,9 @@ main .hero-carousel .hero-carousel-content::before {
   z-index: 1;
   background: linear-gradient(
     to right,
-    rgb(0 0 0 / 70%) 0%,
-    rgb(0 0 0 / 50%) 40%,
-    rgb(0 0 0 / 10%) 70%,
+    rgb(0 0 0 / 65%) 0%,
+    rgb(0 0 0 / 45%) 40%,
+    rgb(0 0 0 / 10%) 65%,
     transparent 100%
   );
   pointer-events: none;
@@ -73,7 +73,7 @@ main .hero-carousel .hero-carousel-content {
   display: flex;
   align-items: center;
   flex: 1;
-  padding: var(--spacing-xl) var(--spacing-m);
+  padding: 40px 20px 60px;
 }
 
 /* Constrained inner container */
@@ -81,174 +81,173 @@ main .hero-carousel .hero-carousel-content-inner {
   position: relative;
   z-index: 2;
   width: 100%;
-  max-width: var(--max-width-site);
+  max-width: 1312px;
   margin: 0 auto;
-  padding: 0 var(--spacing-m);
+  padding: 0 24px;
 }
 
-/* Heading */
+/* Heading — uppercase, bold, tight line-height */
 main .hero-carousel .hero-carousel-content h1 {
-  color: var(--text-light-color);
+  color: white;
+  font-size: 40px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  line-height: 1;
   max-width: 600px;
-  margin-bottom: var(--spacing-s);
+  margin-bottom: 16px;
 }
 
 /* Description */
 main .hero-carousel .hero-carousel-content p {
-  color: var(--text-light-color);
-  font-size: var(--body-font-size-m);
-  line-height: 1.5;
-  max-width: 540px;
-  margin-bottom: var(--spacing-s);
+  color: #e5e5e5;
+  font-size: 16px;
+  line-height: 1.45;
+  max-width: 480px;
+  margin-bottom: 12px;
 }
 
-/* CTA button */
+/* CTA button — white background, pill shape */
 main .hero-carousel .hero-carousel-cta {
-  margin-top: var(--spacing-m);
+  margin-top: 20px;
 }
 
 main .hero-carousel .hero-carousel-cta a.button {
-  background-color: var(--color-hpe-green);
-  color: var(--text-light-color);
-  border-radius: var(--button-border-radius);
-  padding: var(--button-padding);
-  font-size: var(--button-font-size);
-  font-weight: var(--button-font-weight);
+  background-color: white;
+  color: var(--dark-color);
+  border-radius: 100px;
+  padding: 12px 24px;
+  font-size: 18px;
+  font-weight: 500;
   text-decoration: none;
-  transition: var(--button-transition);
+  display: inline-block;
+  transition: background-color 0.2s, color 0.2s;
+  border: none;
 }
 
 main .hero-carousel .hero-carousel-cta a.button:hover {
-  background-color: var(--color-hpe-green-hover);
+  background-color: #e5e5e5;
+  color: var(--dark-color);
   text-decoration: none;
 }
 
-/* ===== Navigation Arrows ===== */
+/* ===== Navigation Arrows — bottom-right, light gray circles ===== */
 main .hero-carousel .hero-carousel-nav {
   position: absolute;
-  bottom: var(--spacing-m);
-  right: var(--spacing-m);
+  bottom: 24px;
+  right: 24px;
   z-index: 10;
   display: flex;
-  gap: var(--spacing-xs);
+  gap: 8px;
 }
 
 main .hero-carousel .hero-carousel-prev,
 main .hero-carousel .hero-carousel-next {
   width: 40px;
   height: 40px;
-  border: 2px solid rgb(255 255 255 / 60%);
+  border: none;
   border-radius: 50%;
-  background: rgb(0 0 0 / 30%);
-  color: white;
+  background: rgb(230 232 233);
+  color: var(--dark-color);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s, border-color 0.2s;
+  transition: background 0.2s;
+  padding: 0;
 }
 
 main .hero-carousel .hero-carousel-prev:hover,
 main .hero-carousel .hero-carousel-next:hover {
-  background: rgb(0 0 0 / 60%);
-  border-color: white;
+  background: rgb(210 212 215);
 }
 
 main .hero-carousel .hero-carousel-prev::after {
   content: '';
   display: block;
-  width: 10px;
-  height: 10px;
-  border-left: 2px solid white;
-  border-bottom: 2px solid white;
+  width: 9px;
+  height: 9px;
+  border-left: 2px solid var(--dark-color);
+  border-bottom: 2px solid var(--dark-color);
   transform: rotate(45deg) translate(2px, -2px);
 }
 
 main .hero-carousel .hero-carousel-next::after {
   content: '';
   display: block;
-  width: 10px;
-  height: 10px;
-  border-right: 2px solid white;
-  border-top: 2px solid white;
+  width: 9px;
+  height: 9px;
+  border-right: 2px solid var(--dark-color);
+  border-top: 2px solid var(--dark-color);
   transform: rotate(45deg) translate(-2px, 2px);
 }
 
-/* ===== Dot Indicators ===== */
+/* ===== Dot Indicators — hidden (source doesn't use dots) ===== */
 main .hero-carousel .hero-carousel-dots {
-  position: absolute;
-  bottom: var(--spacing-m);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 10;
-  display: flex;
-  gap: 8px;
-}
-
-main .hero-carousel .hero-carousel-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 2px solid rgb(255 255 255 / 60%);
-  background: transparent;
-  cursor: pointer;
-  padding: 0;
-  transition: background 0.2s, border-color 0.2s;
-}
-
-main .hero-carousel .hero-carousel-dot.active {
-  background: white;
-  border-color: white;
-}
-
-main .hero-carousel .hero-carousel-dot:hover {
-  border-color: white;
+  display: none;
 }
 
 /* ===== Tablet (600px+) ===== */
 @media (width >= 600px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 440px;
+    min-height: 500px;
   }
 
   main .hero-carousel .hero-carousel-content {
-    padding: var(--spacing-xxl) var(--spacing-l);
+    padding: 48px 32px 72px;
   }
 
   main .hero-carousel .hero-carousel-content-inner {
-    padding: 0 var(--spacing-l);
+    padding: 0 32px;
+  }
+
+  main .hero-carousel .hero-carousel-content h1 {
+    font-size: 60px;
+    letter-spacing: 1.2px;
+  }
+
+  main .hero-carousel .hero-carousel-cta a.button {
+    font-size: 20px;
+    padding: 14px 28px;
   }
 
   main .hero-carousel .hero-carousel-nav {
-    bottom: var(--spacing-l);
-    right: var(--spacing-l);
+    bottom: 32px;
+    right: 32px;
   }
 }
 
 /* ===== Desktop (900px+) ===== */
 @media (width >= 900px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 500px;
+    min-height: 580px;
   }
 
   main .hero-carousel .hero-carousel-content {
-    padding: var(--spacing-xxl) var(--spacing-xl);
+    padding: 60px 40px 96px;
   }
 
-  main .hero-carousel .hero-carousel-content-inner {
-    padding: 0 var(--spacing-l);
+  main .hero-carousel .hero-carousel-content h1 {
+    font-size: 80px;
+    letter-spacing: 1.6px;
+    line-height: 80px;
   }
 
-  main .hero-carousel .hero-carousel-prev,
-  main .hero-carousel .hero-carousel-next {
-    width: 48px;
-    height: 48px;
+  main .hero-carousel .hero-carousel-content p {
+    font-size: 18px;
+    line-height: 26px;
+    max-width: 540px;
   }
 }
 
 /* ===== Wide (1200px+) ===== */
 @media (width >= 1200px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 545px;
+    min-height: 648px;
+  }
+
+  main .hero-carousel .hero-carousel-nav {
+    bottom: 40px;
+    right: 64px;
   }
 }

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -1,6 +1,11 @@
-/* Hero Carousel — full-bleed hero with background image and text overlay */
+/* Hero Carousel — full-bleed hero matching HPE source exactly */
 
-/* Break out of section max-width constraint */
+/* Break out of ALL constraints — true edge-to-edge */
+main .hero-carousel-container {
+  max-width: unset;
+  padding: 0;
+}
+
 main .hero-carousel-container > .hero-carousel-wrapper {
   max-width: unset;
   padding: 0;
@@ -30,7 +35,7 @@ main .hero-carousel .hero-carousel-slide.active {
   visibility: visible;
 }
 
-/* Background image — full bleed, cover */
+/* Background image — full bleed edge-to-edge */
 main .hero-carousel .hero-carousel-bg {
   position: absolute;
   inset: 0;
@@ -50,95 +55,91 @@ main .hero-carousel .hero-carousel-bg img {
   object-fit: cover;
 }
 
-/* Dark gradient overlay for text readability */
-main .hero-carousel .hero-carousel-content::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: linear-gradient(
-    to right,
-    rgb(0 0 0 / 65%) 0%,
-    rgb(0 0 0 / 45%) 40%,
-    rgb(0 0 0 / 10%) 65%,
-    transparent 100%
-  );
-  pointer-events: none;
-}
+/* NO gradient overlay — source uses dark text on naturally light image areas */
 
 /* Content overlay */
 main .hero-carousel .hero-carousel-content {
   position: relative;
   z-index: 1;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   flex: 1;
-  padding: 40px 20px 60px;
+  padding: 40px 24px 48px;
 }
 
-/* Constrained inner container */
+/* Constrained inner container — content starts at ~64px from left edge */
 main .hero-carousel .hero-carousel-content-inner {
   position: relative;
   z-index: 2;
   width: 100%;
   max-width: 1312px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0;
 }
 
-/* Heading — uppercase, bold, tight line-height */
+/* Heading — dark color, uppercase, condensed feel */
 main .hero-carousel .hero-carousel-content h1 {
-  color: white;
-  font-size: 40px;
+  color: var(--dark-color);
+  font-size: 36px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.8px;
+  letter-spacing: 0.5px;
   line-height: 1;
   max-width: 600px;
   margin-bottom: 16px;
 }
 
-/* Description */
+/* Description — dark text */
 main .hero-carousel .hero-carousel-content p {
-  color: #e5e5e5;
+  color: var(--text-secondary-color);
   font-size: 16px;
   line-height: 1.45;
   max-width: 480px;
   margin-bottom: 12px;
 }
 
-/* CTA button — white background, pill shape */
+/* CTA button — dark bg, pill shape, with arrow */
 main .hero-carousel .hero-carousel-cta {
   margin-top: 20px;
 }
 
 main .hero-carousel .hero-carousel-cta a.button {
-  background-color: white;
-  color: var(--dark-color);
+  background-color: var(--dark-color);
+  color: white;
   border-radius: 100px;
-  padding: 12px 24px;
+  padding: 14px 28px;
   font-size: 18px;
   font-weight: 500;
   text-decoration: none;
-  display: inline-block;
-  transition: background-color 0.2s, color 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: background-color 0.2s;
   border: none;
 }
 
+main .hero-carousel .hero-carousel-cta a.button::after {
+  content: '\2192';
+  font-size: 1.2em;
+  transition: transform 0.2s;
+}
+
 main .hero-carousel .hero-carousel-cta a.button:hover {
-  background-color: #e5e5e5;
-  color: var(--dark-color);
+  background-color: var(--dark-alt-color);
   text-decoration: none;
 }
 
-/* ===== Navigation Arrows — bottom-right, light gray circles ===== */
+main .hero-carousel .hero-carousel-cta a.button:hover::after {
+  transform: translateX(4px);
+}
+
+/* ===== Navigation Arrows — bottom-left, below image, dark gray circles ===== */
 main .hero-carousel .hero-carousel-nav {
-  position: absolute;
-  bottom: 24px;
-  right: 24px;
+  position: relative;
   z-index: 10;
   display: flex;
-  gap: 8px;
+  gap: 12px;
+  padding: 16px 24px;
 }
 
 main .hero-carousel .hero-carousel-prev,
@@ -147,8 +148,7 @@ main .hero-carousel .hero-carousel-next {
   height: 40px;
   border: none;
   border-radius: 50%;
-  background: rgb(230 232 233);
-  color: var(--dark-color);
+  background: rgb(83 92 102);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -159,7 +159,7 @@ main .hero-carousel .hero-carousel-next {
 
 main .hero-carousel .hero-carousel-prev:hover,
 main .hero-carousel .hero-carousel-next:hover {
-  background: rgb(210 212 215);
+  background: rgb(65 72 80);
 }
 
 main .hero-carousel .hero-carousel-prev::after {
@@ -167,8 +167,8 @@ main .hero-carousel .hero-carousel-prev::after {
   display: block;
   width: 9px;
   height: 9px;
-  border-left: 2px solid var(--dark-color);
-  border-bottom: 2px solid var(--dark-color);
+  border-left: 2px solid white;
+  border-bottom: 2px solid white;
   transform: rotate(45deg) translate(2px, -2px);
 }
 
@@ -177,33 +177,24 @@ main .hero-carousel .hero-carousel-next::after {
   display: block;
   width: 9px;
   height: 9px;
-  border-right: 2px solid var(--dark-color);
-  border-top: 2px solid var(--dark-color);
+  border-right: 2px solid white;
+  border-top: 2px solid white;
   transform: rotate(45deg) translate(-2px, 2px);
-}
-
-/* ===== Dot Indicators — hidden (source doesn't use dots) ===== */
-main .hero-carousel .hero-carousel-dots {
-  display: none;
 }
 
 /* ===== Tablet (600px+) ===== */
 @media (width >= 600px) {
   main .hero-carousel .hero-carousel-slide {
-    min-height: 500px;
+    min-height: 480px;
   }
 
   main .hero-carousel .hero-carousel-content {
-    padding: 48px 32px 72px;
-  }
-
-  main .hero-carousel .hero-carousel-content-inner {
-    padding: 0 32px;
+    padding: 48px 40px 56px;
   }
 
   main .hero-carousel .hero-carousel-content h1 {
-    font-size: 60px;
-    letter-spacing: 1.2px;
+    font-size: 56px;
+    letter-spacing: 1px;
   }
 
   main .hero-carousel .hero-carousel-cta a.button {
@@ -212,8 +203,7 @@ main .hero-carousel .hero-carousel-dots {
   }
 
   main .hero-carousel .hero-carousel-nav {
-    bottom: 32px;
-    right: 32px;
+    padding: 16px 40px;
   }
 }
 
@@ -224,13 +214,19 @@ main .hero-carousel .hero-carousel-dots {
   }
 
   main .hero-carousel .hero-carousel-content {
-    padding: 60px 40px 96px;
+    padding: 60px 64px 80px;
+    align-items: center;
+  }
+
+  main .hero-carousel .hero-carousel-content-inner {
+    max-width: unset;
   }
 
   main .hero-carousel .hero-carousel-content h1 {
     font-size: 80px;
     letter-spacing: 1.6px;
     line-height: 80px;
+    max-width: 660px;
   }
 
   main .hero-carousel .hero-carousel-content p {
@@ -238,16 +234,15 @@ main .hero-carousel .hero-carousel-dots {
     line-height: 26px;
     max-width: 540px;
   }
+
+  main .hero-carousel .hero-carousel-nav {
+    padding: 20px 64px;
+  }
 }
 
 /* ===== Wide (1200px+) ===== */
 @media (width >= 1200px) {
   main .hero-carousel .hero-carousel-slide {
     min-height: 648px;
-  }
-
-  main .hero-carousel .hero-carousel-nav {
-    bottom: 40px;
-    right: 64px;
   }
 }

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -45,17 +45,6 @@ export default async function decorate(block) {
   let current = 0;
   let autoplayTimer = null;
 
-  // Dot indicators (built first so goTo can reference them)
-  const dotsWrap = document.createElement('div');
-  dotsWrap.className = 'hero-carousel-dots';
-  const dots = slides.map((_, i) => {
-    const dot = document.createElement('button');
-    dot.className = `hero-carousel-dot${i === 0 ? ' active' : ''}`;
-    dot.setAttribute('aria-label', `Go to slide ${i + 1}`);
-    dotsWrap.append(dot);
-    return dot;
-  });
-
   function stopAutoplay() {
     if (autoplayTimer) {
       clearInterval(autoplayTimer);
@@ -65,10 +54,8 @@ export default async function decorate(block) {
 
   function goTo(index) {
     slides[current].classList.remove('active');
-    dots[current].classList.remove('active');
     current = (index + slides.length) % slides.length;
     slides[current].classList.add('active');
-    dots[current].classList.add('active');
   }
 
   function startAutoplay() {
@@ -76,28 +63,22 @@ export default async function decorate(block) {
     autoplayTimer = setInterval(() => goTo(current + 1), 6000);
   }
 
-  // Wire up dot clicks
-  dots.forEach((dot, i) => {
-    dot.addEventListener('click', () => { goTo(i); startAutoplay(); });
-  });
-
-  // Navigation arrows
+  // Navigation arrows (bottom-right, matching source)
   const nav = document.createElement('div');
   nav.className = 'hero-carousel-nav';
 
   const prevBtn = document.createElement('button');
   prevBtn.className = 'hero-carousel-prev';
-  prevBtn.setAttribute('aria-label', 'Previous slide');
+  prevBtn.setAttribute('aria-label', 'Previous');
   prevBtn.addEventListener('click', () => { goTo(current - 1); startAutoplay(); });
 
   const nextBtn = document.createElement('button');
   nextBtn.className = 'hero-carousel-next';
-  nextBtn.setAttribute('aria-label', 'Next slide');
+  nextBtn.setAttribute('aria-label', 'Next');
   nextBtn.addEventListener('click', () => { goTo(current + 1); startAutoplay(); });
 
   nav.append(prevBtn, nextBtn);
   block.append(nav);
-  block.append(dotsWrap);
 
   startAutoplay();
 }

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -1,32 +1,27 @@
 /**
  * Hero Carousel Block
  * Full-bleed hero with background image, text overlay, and CTA.
- * Supports multiple slides (single static slide for Summit demo).
+ * Supports multiple slides with prev/next navigation and dot indicators.
  * @param {Element} block The hero-carousel block element
  */
 export default async function decorate(block) {
   const slides = [...block.children];
+  if (slides.length === 0) return;
 
-  slides.forEach((slide) => {
+  slides.forEach((slide, i) => {
     const [imageCell, contentCell] = [...slide.children];
 
-    // Mark the slide
     slide.classList.add('hero-carousel-slide');
+    if (i === 0) slide.classList.add('active');
 
-    // Set up image as background
     if (imageCell) {
       imageCell.classList.add('hero-carousel-bg');
       const img = imageCell.querySelector('img');
-      if (img) {
-        img.loading = 'eager';
-      }
+      if (img) img.loading = i === 0 ? 'eager' : 'lazy';
     }
 
-    // Set up content overlay
     if (contentCell) {
       contentCell.classList.add('hero-carousel-content');
-
-      // Wrap content in a constrained container
       const inner = document.createElement('div');
       inner.classList.add('hero-carousel-content-inner');
       while (contentCell.firstChild) {
@@ -34,7 +29,6 @@ export default async function decorate(block) {
       }
       contentCell.appendChild(inner);
 
-      // Style CTA links as buttons
       inner.querySelectorAll('a').forEach((a) => {
         const p = a.closest('p');
         if (p) {
@@ -44,4 +38,66 @@ export default async function decorate(block) {
       });
     }
   });
+
+  // Only add carousel controls if there are multiple slides
+  if (slides.length <= 1) return;
+
+  let current = 0;
+  let autoplayTimer = null;
+
+  // Dot indicators (built first so goTo can reference them)
+  const dotsWrap = document.createElement('div');
+  dotsWrap.className = 'hero-carousel-dots';
+  const dots = slides.map((_, i) => {
+    const dot = document.createElement('button');
+    dot.className = `hero-carousel-dot${i === 0 ? ' active' : ''}`;
+    dot.setAttribute('aria-label', `Go to slide ${i + 1}`);
+    dotsWrap.append(dot);
+    return dot;
+  });
+
+  function stopAutoplay() {
+    if (autoplayTimer) {
+      clearInterval(autoplayTimer);
+      autoplayTimer = null;
+    }
+  }
+
+  function goTo(index) {
+    slides[current].classList.remove('active');
+    dots[current].classList.remove('active');
+    current = (index + slides.length) % slides.length;
+    slides[current].classList.add('active');
+    dots[current].classList.add('active');
+  }
+
+  function startAutoplay() {
+    stopAutoplay();
+    autoplayTimer = setInterval(() => goTo(current + 1), 6000);
+  }
+
+  // Wire up dot clicks
+  dots.forEach((dot, i) => {
+    dot.addEventListener('click', () => { goTo(i); startAutoplay(); });
+  });
+
+  // Navigation arrows
+  const nav = document.createElement('div');
+  nav.className = 'hero-carousel-nav';
+
+  const prevBtn = document.createElement('button');
+  prevBtn.className = 'hero-carousel-prev';
+  prevBtn.setAttribute('aria-label', 'Previous slide');
+  prevBtn.addEventListener('click', () => { goTo(current - 1); startAutoplay(); });
+
+  const nextBtn = document.createElement('button');
+  nextBtn.className = 'hero-carousel-next';
+  nextBtn.setAttribute('aria-label', 'Next slide');
+  nextBtn.addEventListener('click', () => { goTo(current + 1); startAutoplay(); });
+
+  nav.append(prevBtn, nextBtn);
+  block.append(nav);
+  block.append(dotsWrap);
+
+  startAutoplay();
 }

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -1,12 +1,22 @@
 /**
- * Hero Carousel Block
- * Full-bleed hero with background image, text overlay, and CTA.
- * Supports multiple slides with prev/next navigation and dot indicators.
+ * Hero Carousel Block — matches HPE source structure exactly.
+ *
+ * Source layout per slide:
+ *   slide (position:relative, display:flex, flex-direction:row, overflow:hidden)
+ *     img  (position:absolute, inset:0, object-fit:cover — fills entire slide)
+ *     .content (position:relative, z-index:1, flex child — text sits on left)
+ *
+ * Nav arrows sit at bottom-left INSIDE the carousel (position:absolute).
+ *
  * @param {Element} block The hero-carousel block element
  */
 export default async function decorate(block) {
   const slides = [...block.children];
   if (slides.length === 0) return;
+
+  // Wrap all slides in a slides container
+  const slidesContainer = document.createElement('div');
+  slidesContainer.className = 'hero-carousel-slides';
 
   slides.forEach((slide, i) => {
     const [imageCell, contentCell] = [...slide.children];
@@ -14,30 +24,41 @@ export default async function decorate(block) {
     slide.classList.add('hero-carousel-slide');
     if (i === 0) slide.classList.add('active');
 
+    // Image: pull img out of its cell, make it a direct child of slide
+    // so it can be position:absolute covering the entire slide
     if (imageCell) {
-      imageCell.classList.add('hero-carousel-bg');
       const img = imageCell.querySelector('img');
-      if (img) img.loading = i === 0 ? 'eager' : 'lazy';
+      if (img) {
+        img.classList.add('hero-carousel-bg-img');
+        img.loading = i === 0 ? 'eager' : 'lazy';
+        slide.prepend(img);
+      }
+      imageCell.remove();
     }
 
+    // Content: becomes the flex child with text
     if (contentCell) {
       contentCell.classList.add('hero-carousel-content');
-      const inner = document.createElement('div');
-      inner.classList.add('hero-carousel-content-inner');
-      while (contentCell.firstChild) {
-        inner.appendChild(contentCell.firstChild);
-      }
-      contentCell.appendChild(inner);
 
-      inner.querySelectorAll('a').forEach((a) => {
+      // Style CTA links as pill buttons with arrow
+      contentCell.querySelectorAll('a').forEach((a) => {
         const p = a.closest('p');
         if (p) {
           a.classList.add('button');
           p.classList.add('hero-carousel-cta');
+          // Add arrow span matching source structure
+          const arrow = document.createElement('span');
+          arrow.className = 'hero-carousel-arrow';
+          a.append(arrow);
         }
       });
     }
+
+    slidesContainer.append(slide);
   });
+
+  block.textContent = '';
+  block.append(slidesContainer);
 
   // Only add carousel controls if there are multiple slides
   if (slides.length <= 1) return;
@@ -63,7 +84,7 @@ export default async function decorate(block) {
     autoplayTimer = setInterval(() => goTo(current + 1), 6000);
   }
 
-  // Navigation arrows (bottom-right, matching source)
+  // Navigation arrows — bottom-left inside the carousel (position:absolute)
   const nav = document.createElement('div');
   nav.className = 'hero-carousel-nav';
 


### PR DESCRIPTION
## Summary
Complete architectural rewrite of hero-carousel to match HPE source structure, based on deep-dive DOM inspection.

### Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-hero-structural-rewrite--summit-hpp--aemdemos.aem.page/us/en/home

### Key Structural Changes
| Property | Before (wrong) | After (matches source) |
|----------|---------------|----------------------|
| Slide layout | Image absolute + content overlaid | Flex-row: absolute image + relative content child |
| Image | `position:absolute; inset:0` in a wrapper div | Direct `<img>` as child, `position:absolute; inset:0; object-fit:cover` |
| Content | Overlaid with z-index, full width | Flex child, `margin-left:64px`, `max-width:656px` |
| Nav arrows | Bottom-right (then bottom-left in flow) | `position:absolute; bottom:0; left:64px` inside carousel |
| CTA arrow | CSS `::after` unicode `→` | SVG `<span>` inside link (source pattern) |
| Carousel overflow | `hidden` | `visible` (source) |
| Slide height | `min-height` based | Fixed `height` matching source (648px at 1200px+) |

### Source measurements used
- Carousel: 1440x658, left:0 (edge-to-edge)
- Slide: 1440x648, `display:flex; flex-direction:row; overflow:hidden`
- Content: left:64, width:1312, `padding: 60px 0 96px`
- H1: 80px, #292d3a, uppercase, weight 700, letter-spacing 1.6px
- CTA: bg #292d3a, pill, 20px, flex + gap:12px, arrow-icon span
- Nav: absolute left:64, top:632, 40x40, bg #535c66, gap:12px

## Test plan
- [ ] Only one slide visible at a time (crossfade transition)
- [ ] Image covers full slide edge-to-edge
- [ ] Text content sits on left side with 64px margin from viewport
- [ ] CTA has dark background with SVG arrow
- [ ] Nav arrows at bottom-left, below the slide content
- [ ] Auto-rotates every 6 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)