### PR TITLE
fix: Hero carousel pixel-parity — fonts, layout, and crossfade

### DIFF
--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -19,7 +19,15 @@ main .hero-carousel {
   overflow: visible;
 }
 
-/* ===== SLIDE: position relative so absolute image fills it ===== */
+/* ===== SLIDES CONTAINER: explicit height so absolute children are visible ===== */
+main .hero-carousel .hero-carousel-slides {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  height: clamp(420px, calc(100vh - 80px), 900px);
+}
+
+/* ===== SLIDE: all absolute — avoids layout shift during crossfade ===== */
 main .hero-carousel .hero-carousel-slide {
   position: absolute;
   inset: 0;
@@ -29,21 +37,14 @@ main .hero-carousel .hero-carousel-slide {
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.8s ease-in-out, visibility 0.8s;
-  height: clamp(420px, calc(100vh - 80px), 900px);
   width: 100%;
+  height: 100%;
 }
 
 main .hero-carousel .hero-carousel-slide.active {
-  position: relative;
   opacity: 1;
   visibility: visible;
-}
-
-/* Ensure slides container defines the height for absolute children */
-main .hero-carousel .hero-carousel-slides {
-  position: relative;
-  width: 100%;
-  overflow: hidden;
+  z-index: 1;
 }
 
 /* ===== IMAGE: absolute, covers entire slide edge-to-edge ===== */


### PR DESCRIPTION
## Summary
- Complete CSS rewrite of hero carousel for pixel-parity with the HPE source site
- Added HPEGraphik condensed font faces for hero H1 headings
- Fixed slide overlap during crossfade transitions (all slides now absolutely positioned with explicit container height)
- Edge-to-edge hero images that override EDS specificity constraints
- Responsive height using `clamp(420px, calc(100vh - 80px), 900px)`

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-hero-r1-font-and-theme--summit-hpp--aemdemos.aem.page/us/en/home

## Files changed
- `blocks/hero-carousel/hero-carousel.css` — Full layout and styling rewrite
- `blocks/hero-carousel/hero-carousel.js` — Slide decoration and carousel logic
- `styles/fonts.css` — HPEGraphik condensed font face declarations

## Test plan
- [ ] Hero carousel displays single slide without overlap
- [ ] Crossfade transitions are smooth (no layout shift)
- [ ] Hero fills viewport below header on all breakpoints
- [ ] H1 renders in condensed uppercase HPEGraphik font
- [ ] CTA pill button with arrow icon is clickable
- [ ] Prev/Next navigation buttons work
- [ ] Autoplay cycles every 6 seconds
- [ ] Run PageSpeed Insights on branch preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)