### PR TITLE
fix: Header desktop nav — logo, centered links, chevrons, icons

### DIFF
--- a/blocks/header/header-tokens.css
+++ b/blocks/header/header-tokens.css
@@ -6,7 +6,7 @@
   --header-nav-padding-desktop: 0 32px;
   --header-nav-gap: 24px;
   --header-nav-gap-desktop: 32px;
-  --header-brand-width: 128px;
+  --header-brand-width: 64px;
   --header-dropdown-width: 200px;
   --header-dropdown-padding: 16px;
   --header-dropdown-left: -24px;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -239,7 +239,7 @@ header nav .nav-tools-lang:hover {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 0 var(--header-nav-gap-desktop);
+    gap: 0;
     max-width: var(--header-nav-max-width-desktop);
     padding: var(--header-nav-padding-desktop);
   }
@@ -254,10 +254,16 @@ header nav .nav-tools-lang:hover {
     visibility: hidden;
   }
 
+  header nav .nav-brand {
+    flex: 0 0 auto;
+  }
+
   header nav .nav-sections {
-    display: block;
+    display: flex;
     visibility: visible;
     white-space: nowrap;
+    flex: 1 1 auto;
+    justify-content: center;
   }
 
   header nav[aria-expanded='true'] .nav-sections {
@@ -279,7 +285,7 @@ header nav .nav-tools-lang:hover {
 
   header nav .nav-sections .default-content-wrapper > ul > li > a {
     display: inline-block;
-    padding: 8px 12px;
+    padding: 8px 14px;
     font-size: var(--body-font-size-m);
     font-weight: 400;
     color: rgb(212 212 212);
@@ -294,28 +300,70 @@ header nav .nav-tools-lang:hover {
     color: var(--text-light-color);
   }
 
+  header nav .nav-tools {
+    flex: 0 0 auto;
+  }
+
   header nav .nav-tools-lang {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border-radius: 50%;
+    transition: background-color var(--transition-base);
+  }
+
+  header nav .nav-tools-lang:hover {
+    background-color: rgb(255 255 255 / 10%);
+  }
+
+  header nav .nav-tools-lang .icon {
     display: inline-block;
+    width: 20px;
+    height: 20px;
   }
 
   /* Dropdown buttons */
   header nav .nav-drop-toggle {
     background: none;
     border: none;
-    color: white;
+    color: rgb(212 212 212);
     font-family: var(--body-font-family);
-    font-size: var(--body-font-size-s);
-    font-weight: 500;
+    font-size: var(--body-font-size-m);
+    font-weight: 400;
     cursor: pointer;
-    padding: 8px 16px;
-    border-radius: 100px;
-    transition: background var(--transition-base);
+    padding: 8px 14px;
+    border-radius: var(--button-border-radius);
+    transition: background var(--transition-base), color var(--transition-base);
     white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
 
   header nav .nav-drop-toggle:hover,
   header nav .nav-drop-toggle[aria-expanded="true"] {
-    background: rgb(255 255 255 / 15%);
+    background: rgb(255 255 255 / 10%);
+    color: var(--text-light-color);
+  }
+
+  /* Dropdown chevron */
+  header nav .nav-drop-chevron {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-right: 1.5px solid currentcolor;
+    border-bottom: 1.5px solid currentcolor;
+    transform: rotate(45deg);
+    margin-top: -3px;
+    transition: transform 0.2s;
+  }
+
+  header nav .nav-drop-toggle[aria-expanded="true"] .nav-drop-chevron {
+    transform: rotate(-135deg);
+    margin-top: 2px;
   }
 
   header nav .nav-sections li {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,4 +1,4 @@
-import { getMetadata } from '../../scripts/aem.js';
+import { getMetadata, decorateIcons } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 
 const isDesktop = window.matchMedia('(min-width: 900px)');
@@ -89,9 +89,13 @@ export default async function decorate(block) {
           const dropBtn = document.createElement('button');
           dropBtn.type = 'button';
           dropBtn.className = 'nav-drop-toggle';
-          dropBtn.textContent = text;
           dropBtn.setAttribute('aria-expanded', 'false');
           dropBtn.setAttribute('aria-haspopup', 'true');
+          dropBtn.textContent = text;
+          const chevron = document.createElement('span');
+          chevron.className = 'nav-drop-chevron';
+          chevron.setAttribute('aria-hidden', 'true');
+          dropBtn.append(chevron);
 
           const dropPanel = document.createElement('div');
           dropPanel.className = 'nav-drop-panel';
@@ -148,12 +152,14 @@ export default async function decorate(block) {
   searchBtn.append(searchIcon);
   navTools.append(searchBtn);
 
-  // Language selector
+  // Language selector (globe icon)
   const langLink = document.createElement('a');
-  langLink.href = '/us/en/home.html';
+  langLink.href = '/us/en/country-selector.html';
   langLink.className = 'nav-tools-lang';
-  langLink.textContent = 'EN';
-  langLink.setAttribute('aria-label', 'Select language');
+  langLink.setAttribute('aria-label', 'Change language');
+  const globeIcon = document.createElement('span');
+  globeIcon.className = 'icon icon-globe';
+  langLink.append(globeIcon);
   navTools.append(langLink);
 
   nav.append(navTools);
@@ -181,4 +187,7 @@ export default async function decorate(block) {
   navWrapper.className = 'nav-wrapper';
   navWrapper.append(nav);
   block.append(navWrapper);
+
+  // Load SVG icons for search and globe
+  decorateIcons(navTools);
 }

--- a/icons/globe.svg
+++ b/icons/globe.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M2 12h20"/>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+</svg>

--- a/icons/hpe-logo.svg
+++ b/icons/hpe-logo.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 216 36" fill="#01a982">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 36" fill="#01a982">
   <path d="M46.7 0H36.1L24.8 14.6h10.6L46.7 0zM35 21.4H24.4L13.1 36h10.6L35 21.4zM23.3 14.6H12.7L1.4 29.2h10.6l11.3-14.6zM58.4 6.8H47.8L36.5 21.4h10.6L58.4 6.8z"/>
-  <text x="68" y="26" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#01a982">Hewlett Packard Enterprise</text>
 </svg>


### PR DESCRIPTION
## Summary
- Compact green HPE mark replaces full wordmark (prevents text clipping at all viewports)
- Nav links centered between logo and tools via flexbox
- Dropdown chevrons (∨) on GreenLake, Solutions, Products, Support, Company
- Search magnifying glass and globe language icons visible at desktop
- `decorateIcons` called on nav tools for SVG loading

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-header-desktop-nav--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Desktop (900px+): Logo + centered nav links with chevrons + search/globe icons
- [ ] Mobile (<900px): Hamburger menu still works
- [ ] Dropdown buttons toggle panels on click
- [ ] Search and globe icons render as SVGs
- [ ] No lint errors

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)