### PR TITLE
fix: News carousel — wider cards, working nav, control bar

### DIFF
--- a/blocks/news-carousel/news-carousel.css
+++ b/blocks/news-carousel/news-carousel.css
@@ -13,15 +13,10 @@ main .news-carousel .news-carousel-heading {
   margin-bottom: var(--spacing-l);
 }
 
-/* Track wrapper — positions nav buttons relative to track */
-main .news-carousel .news-carousel-track-wrapper {
-  position: relative;
-}
-
 /* Scrolling card track */
 main .news-carousel .news-carousel-track {
   display: flex;
-  gap: var(--spacing-s);
+  gap: var(--spacing-m);
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
@@ -36,10 +31,10 @@ main .news-carousel .news-carousel-track::-webkit-scrollbar {
 
 /* Individual card */
 main .news-carousel .news-carousel-card {
-  flex: 0 0 236px;
-  min-width: 236px;
+  flex: 0 0 280px;
+  min-width: 280px;
   background-color: var(--dark-alt-color);
-  border-radius: 8px;
+  border-radius: 12px;
   overflow: hidden;
   scroll-snap-align: start;
   display: flex;
@@ -51,10 +46,10 @@ main .news-carousel .news-carousel-card:hover {
   transform: translateY(-2px);
 }
 
-/* Card image */
+/* Card image — wider aspect ratio matching source */
 main .news-carousel .news-carousel-card-image {
   width: 100%;
-  aspect-ratio: 2 / 3;
+  aspect-ratio: 16 / 10;
   overflow: hidden;
 }
 
@@ -76,7 +71,7 @@ main .news-carousel .news-carousel-card-content {
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: var(--spacing-s);
+  padding: var(--spacing-m);
   gap: var(--spacing-xs);
 }
 
@@ -85,7 +80,7 @@ main .news-carousel .news-carousel-card-title {
   color: var(--text-light-color);
   font-size: var(--body-font-size-s);
   font-weight: 500;
-  line-height: 1.35;
+  line-height: 1.4;
   margin: 0;
 }
 
@@ -114,28 +109,30 @@ main .news-carousel .news-carousel-card-cta:hover {
   text-decoration: underline;
 }
 
-/* Navigation buttons */
-main .news-carousel .news-carousel-nav {
-  position: absolute;
-  top: 50%;
-  left: -20px;
-  right: -20px;
-  transform: translateY(-50%);
+/* === Control bar: nav buttons (left) + explore link (right) === */
+main .news-carousel .news-carousel-controls {
   display: flex;
   justify-content: space-between;
-  pointer-events: none;
-  z-index: 2;
+  align-items: center;
+  margin-top: var(--spacing-l);
+  gap: var(--spacing-m);
 }
 
+/* Nav buttons container */
+main .news-carousel .news-carousel-nav {
+  display: flex;
+  gap: var(--spacing-s);
+}
+
+/* Nav buttons */
 main .news-carousel .news-carousel-btn {
   width: 40px;
   height: 40px;
   border-radius: 50%;
   border: 1px solid rgb(255 255 255 / 40%);
-  background-color: rgb(0 0 0 / 50%);
+  background-color: transparent;
   color: var(--text-light-color);
   cursor: pointer;
-  pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -146,14 +143,13 @@ main .news-carousel .news-carousel-btn {
 }
 
 main .news-carousel .news-carousel-btn:hover {
-  background-color: rgb(0 0 0 / 70%);
+  background-color: rgb(255 255 255 / 10%);
   border-color: rgb(255 255 255 / 60%);
 }
 
 main .news-carousel .news-carousel-btn:disabled {
   opacity: 0.3;
   cursor: default;
-  background-color: rgb(0 0 0 / 30%);
 }
 
 /* Arrow icons via pseudo-elements */
@@ -176,13 +172,7 @@ main .news-carousel .news-carousel-btn-next::after {
   left: calc(50% - 2px);
 }
 
-/* Footer CTA */
-main .news-carousel .news-carousel-footer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: var(--spacing-l);
-}
-
+/* Explore more news link */
 main .news-carousel .news-carousel-explore {
   display: inline-block;
   padding: 10px 24px;
@@ -202,41 +192,34 @@ main .news-carousel .news-carousel-explore:hover {
   text-decoration: none;
 }
 
-/* === Mobile: show ~1.5 cards === */
+/* === Mobile: show ~1.3 cards === */
 @media (width < 600px) {
   main .news-carousel .news-carousel-card {
-    flex: 0 0 70vw;
-    min-width: 70vw;
+    flex: 0 0 75vw;
+    min-width: 75vw;
   }
 
-  main .news-carousel .news-carousel-nav {
-    left: -12px;
-    right: -12px;
-  }
-}
-
-/* === Tablet === */
-@media (width >= 600px) and (width < 900px) {
-  main .news-carousel .news-carousel-card {
-    flex: 0 0 220px;
-    min-width: 220px;
+  main .news-carousel .news-carousel-controls {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-m);
   }
 }
 
-/* === Desktop === */
+/* === Desktop (900px+) === */
 @media (width >= 900px) {
-  main .news-carousel .news-carousel-nav {
-    left: -24px;
-    right: -24px;
+  main .news-carousel .news-carousel-card {
+    flex: 0 0 calc((100% - 4 * var(--spacing-m)) / 5);
+    min-width: 200px;
   }
 
   main .news-carousel .news-carousel-btn {
-    width: 48px;
-    height: 48px;
+    width: 44px;
+    height: 44px;
   }
 
   main .news-carousel .news-carousel-btn::after {
-    width: 12px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
   }
 }

--- a/blocks/news-carousel/news-carousel.js
+++ b/blocks/news-carousel/news-carousel.js
@@ -38,7 +38,7 @@ export default async function decorate(block) {
       card.append(imageWrap);
     }
 
-    // Content: title + CTA
+    // Content: title + optional description + CTA
     const contentCol = cols[1];
     const contentWrap = document.createElement('div');
     contentWrap.classList.add('news-carousel-card-content');
@@ -77,9 +77,6 @@ export default async function decorate(block) {
   });
 
   // --- Navigation buttons ---
-  const navContainer = document.createElement('div');
-  navContainer.classList.add('news-carousel-nav');
-
   const prevBtn = document.createElement('button');
   prevBtn.classList.add('news-carousel-btn', 'news-carousel-btn-prev');
   prevBtn.setAttribute('aria-label', 'Previous');
@@ -90,31 +87,29 @@ export default async function decorate(block) {
   nextBtn.setAttribute('aria-label', 'Next');
   nextBtn.type = 'button';
 
-  navContainer.append(prevBtn);
-  navContainer.append(nextBtn);
-
-  // --- Track wrapper (contains track + nav) ---
-  const trackWrapper = document.createElement('div');
-  trackWrapper.classList.add('news-carousel-track-wrapper');
-  trackWrapper.append(navContainer);
-  trackWrapper.append(track);
-
   // --- Footer CTA ---
   const footerLink = footerRow.querySelector('a');
-  const footer = document.createElement('div');
-  footer.classList.add('news-carousel-footer');
+
+  // --- Control bar: nav buttons (left) + explore link (right) ---
+  const controlBar = document.createElement('div');
+  controlBar.classList.add('news-carousel-controls');
+
+  const navContainer = document.createElement('div');
+  navContainer.classList.add('news-carousel-nav');
+  navContainer.append(prevBtn, nextBtn);
+  controlBar.append(navContainer);
+
   if (footerLink) {
     footerLink.classList.add('news-carousel-explore');
-    footer.append(footerLink);
+    controlBar.append(footerLink);
   }
 
   // --- Assemble ---
-  // Clear existing rows except heading
   headingRow.remove();
   footerRow.remove();
 
-  block.append(trackWrapper);
-  block.append(footer);
+  block.append(track);
+  block.append(controlBar);
 
   // Reinsert heading at top
   if (heading) {
@@ -140,6 +135,10 @@ export default async function decorate(block) {
   nextBtn.addEventListener('click', () => scrollByCard(1));
   track.addEventListener('scroll', updateButtons, { passive: true });
 
-  // Initial button state
-  updateButtons();
+  // Defer initial button state until layout is complete
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      updateButtons();
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Fixed nav buttons permanently disabled (layout timing bug — deferred with double rAF)
- Card images changed from 2:3 to 16:10 aspect ratio matching source
- Nav buttons + "Explore more news" moved to bottom control bar (buttons left, CTA right)
- Increased card gap and border-radius for cleaner appearance
- Desktop shows ~5 cards, mobile shows ~1.3 for swipe discovery

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-news-carousel-styling--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] 5 cards visible at desktop (1280px) with horizontal scroll
- [ ] Previous disabled at start, Next enabled
- [ ] Click Next scrolls by one card, buttons update state
- [ ] "Explore more news" button at bottom-right
- [ ] Card hover lifts card slightly
- [ ] Mobile shows ~1.3 cards for swipe discovery
- [ ] No lint errors

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)