### PR TITLE
fix: Solutions grid — image zoom hover and CTA arrow icons

### DIFF
--- a/blocks/solutions-grid/solutions-grid.css
+++ b/blocks/solutions-grid/solutions-grid.css
@@ -42,9 +42,13 @@ main .solutions-grid .solutions-grid-tile-link {
 }
 
 main .solutions-grid .solutions-grid-tile-link:hover {
-  transform: scale(1.02);
   box-shadow: var(--shadow-lg);
   text-decoration: none;
+}
+
+/* Image zooms on hover, not the whole tile */
+main .solutions-grid .solutions-grid-tile-link:hover .solutions-grid-tile-bg img {
+  transform: scale(1.08);
 }
 
 /* Tile */
@@ -69,6 +73,7 @@ main .solutions-grid .solutions-grid-tile-bg img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition: transform 0.6s ease;
 }
 
 /* Dark overlay */
@@ -105,16 +110,31 @@ main .solutions-grid .solutions-grid-tile-content p {
   opacity: 0.9;
 }
 
-/* CTA text */
+/* CTA text with arrow */
 main .solutions-grid .solutions-grid-tile-cta a {
   color: var(--color-hpe-green);
   font-size: var(--body-font-size-xs);
   font-weight: 500;
   text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
-main .solutions-grid .solutions-grid-tile-link:hover .solutions-grid-tile-cta a {
-  text-decoration: underline;
+main .solutions-grid .solutions-grid-tile-cta a::after {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-color: var(--color-hpe-green);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  transition: transform 0.2s;
+}
+
+main .solutions-grid .solutions-grid-tile-link:hover .solutions-grid-tile-cta a::after {
+  transform: translateX(4px);
 }
 
 /* Focus visible on tile link */


### PR DESCRIPTION
## Summary
- Background image zooms (scale 1.08) on tile hover instead of scaling entire tile
- CTA links display green arrow icon via CSS mask ("Explore AI →")
- Arrow shifts right 4px on hover
- 0.6s ease transition for smooth image zoom effect

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-solutions-grid-hover--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Hover on tile: background image zooms, tile gets shadow
- [ ] CTA links show green arrow icon
- [ ] Arrow shifts right on hover
- [ ] 3+2 grid layout intact at desktop
- [ ] No lint errors

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)