### PR TITLE
fix: Customer stories — 3-column grid layout for tab panels

### DIFF
--- a/blocks/customer-stories/customer-stories.css
+++ b/blocks/customer-stories/customer-stories.css
@@ -158,24 +158,20 @@ main .customer-stories .customer-stories-grid {
 
 @media (width >= 900px) {
   main .customer-stories .customer-stories-grid {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto;
+    grid-template-columns: 2fr 1fr 1fr;
     gap: var(--spacing-l);
   }
 
   main .customer-stories .customer-stories-intro {
-    grid-row: 1 / 3;
     grid-column: 1;
   }
 
   main .customer-stories .customer-stories-objectives {
-    grid-row: 1;
     grid-column: 2;
   }
 
   main .customer-stories .customer-stories-outcomes {
-    grid-row: 2;
-    grid-column: 2;
+    grid-column: 3;
   }
 }
 
@@ -228,8 +224,9 @@ main .customer-stories .customer-stories-objectives picture {
 
 main .customer-stories .customer-stories-objectives img {
   width: 100%;
-  max-width: 80px;
   height: auto;
+  border-radius: 8px;
+  margin-top: var(--spacing-s);
 }
 
 /* Outcomes section */
@@ -272,8 +269,9 @@ main .customer-stories .customer-stories-outcomes picture {
 
 main .customer-stories .customer-stories-outcomes img {
   width: 100%;
-  max-width: 80px;
+  max-width: 120px;
   height: auto;
+  margin-top: var(--spacing-s);
 }
 
 /* ===== QUOTE ===== */


### PR DESCRIPTION
## Summary
- Desktop grid changed from 2-column (intro spanning 2 rows) to 3-column (`2fr 1fr 1fr`) with intro, objectives, outcomes side-by-side
- Objectives image now fills card width with border-radius instead of 80px max
- Outcomes company logo sized at 120px max-width
- Matches original HPE site's tab panel layout

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-customer-stories-layout--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] KDDI tab shows 3-column grid (intro | objectives | outcomes)
- [ ] Objectives image fills card width
- [ ] KDDI logo visible in outcomes column
- [ ] Tab switching works for all 5 tabs
- [ ] Mobile: stacks to single column
- [ ] No lint errors

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)