### PR TITLE
fix: Product cards — image zoom and card lift on hover

### DIFF
--- a/blocks/product-cards/product-cards.css
+++ b/blocks/product-cards/product-cards.css
@@ -15,11 +15,12 @@ main .product-cards .product-card {
   border: 1px solid var(--border-light-color);
   border-radius: 8px;
   overflow: hidden;
-  transition: box-shadow var(--transition-slow);
+  transition: box-shadow var(--transition-slow), transform var(--transition-slow);
 }
 
 main .product-cards .product-card:hover {
   box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
 }
 
 /* Card image */
@@ -39,6 +40,11 @@ main .product-cards .product-card-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition: transform 0.6s ease;
+}
+
+main .product-cards .product-card:hover .product-card-image img {
+  transform: scale(1.05);
 }
 
 /* Card content */


### PR DESCRIPTION
## Summary
- Image zooms (scale 1.05) on card hover with 0.6s ease transition
- Card lifts 2px with increased shadow on hover
- CSS-only change, no JS modifications

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-product-cards-hover--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Hover on product card: image zooms, card lifts with shadow
- [ ] Arrow CTA still shifts right on hover
- [ ] 2-column and 3-column grid layouts intact
- [ ] No lint errors

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)