### PR TITLE
fix: Hero carousel slide indicator dots

### DIFF
--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -210,6 +210,33 @@ main .hero-carousel .hero-carousel-next::after {
   transform: rotate(45deg) translate(-2px, 2px);
 }
 
+/* ===== SLIDE INDICATORS (dots) ===== */
+main .hero-carousel .hero-carousel-indicators {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 12px;
+}
+
+main .hero-carousel .hero-carousel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid rgb(230 232 233);
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+main .hero-carousel .hero-carousel-dot.active {
+  background: rgb(230 232 233);
+}
+
+main .hero-carousel .hero-carousel-dot:hover {
+  border-color: white;
+}
+
 /* ===== TABLET (600px+) ===== */
 @media (width >= 600px) {
   main .hero-carousel .hero-carousel-content {

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -91,10 +91,19 @@ export default async function decorate(block) {
     }
   }
 
+  function updateIndicators() {
+    const dots = block.querySelectorAll('.hero-carousel-dot');
+    dots.forEach((dot, i) => {
+      dot.classList.toggle('active', i === current);
+      dot.setAttribute('aria-selected', i === current ? 'true' : 'false');
+    });
+  }
+
   function goTo(index) {
     slides[current].classList.remove('active');
     current = (index + slides.length) % slides.length;
     slides[current].classList.add('active');
+    updateIndicators();
   }
 
   function startAutoplay() {
@@ -115,7 +124,23 @@ export default async function decorate(block) {
   nextBtn.setAttribute('aria-label', 'Next');
   nextBtn.addEventListener('click', () => { goTo(current + 1); startAutoplay(); });
 
-  nav.append(prevBtn, nextBtn);
+  // Slide indicators (dots)
+  const indicators = document.createElement('div');
+  indicators.className = 'hero-carousel-indicators';
+  indicators.setAttribute('role', 'tablist');
+
+  slides.forEach((_, i) => {
+    const dot = document.createElement('button');
+    dot.className = 'hero-carousel-dot';
+    if (i === 0) dot.classList.add('active');
+    dot.setAttribute('role', 'tab');
+    dot.setAttribute('aria-label', `Slide ${i + 1}`);
+    dot.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+    dot.addEventListener('click', () => { goTo(i); startAutoplay(); });
+    indicators.append(dot);
+  });
+
+  nav.append(prevBtn, nextBtn, indicators);
   block.append(nav);
 
   startAutoplay();


### PR DESCRIPTION
## Summary
- Added dot indicators next to prev/next arrows showing total slides
- Active dot filled, inactive dots outlined
- Clicking a dot navigates to that slide and restarts autoplay
- Dots update on all slide changes (nav buttons, autoplay, dot clicks)
- Proper ARIA roles (tablist/tab with aria-selected)

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-hero-slide-indicators--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] 2 dots visible next to prev/next arrows
- [ ] Active slide dot is filled
- [ ] Clicking dot 2 navigates to slide 2
- [ ] Dots update when using prev/next buttons
- [ ] Dots update during autoplay rotation
- [ ] No lint errors

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)