### PR TITLE
fix: Desktop 1920px parity — header, hero, news carousel sizing

### DIFF
--- a/blocks/header/header-tokens.css
+++ b/blocks/header/header-tokens.css
@@ -1,9 +1,9 @@
 /* header design tokens (layout only; colors/typography use global tokens) */
 :root {
   --header-nav-max-width: 1248px;
-  --header-nav-max-width-desktop: 1264px;
+  --header-nav-max-width-desktop: 1680px;
   --header-nav-padding: 0 24px;
-  --header-nav-padding-desktop: 0 32px;
+  --header-nav-padding-desktop: 0 120px;
   --header-nav-gap: 24px;
   --header-nav-gap-desktop: 32px;
   --header-brand-width: 64px;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -263,7 +263,7 @@ header nav .nav-tools-lang:hover {
     visibility: visible;
     white-space: nowrap;
     flex: 1 1 auto;
-    justify-content: center;
+    justify-content: flex-end;
   }
 
   header nav[aria-expanded='true'] .nav-sections {
@@ -285,7 +285,7 @@ header nav .nav-tools-lang:hover {
 
   header nav .nav-sections .default-content-wrapper > ul > li > a {
     display: inline-block;
-    padding: 8px 14px;
+    padding: 8px 22px;
     font-size: var(--body-font-size-m);
     font-weight: 400;
     color: rgb(212 212 212);
@@ -334,7 +334,7 @@ header nav .nav-tools-lang:hover {
     font-size: var(--body-font-size-m);
     font-weight: 400;
     cursor: pointer;
-    padding: 8px 14px;
+    padding: 8px 22px;
     border-radius: var(--button-border-radius);
     transition: background var(--transition-base), color var(--transition-base);
     white-space: nowrap;

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -127,8 +127,8 @@ main .hero-carousel .hero-carousel-cta a.button {
   color: var(--dark-color);
   border: none;
   border-radius: 100px;
-  padding: 14px 28px;
-  font-size: 18px;
+  padding: 18px 36px;
+  font-size: 20px;
   font-weight: 500;
   text-decoration: none;
   display: inline-flex;
@@ -171,8 +171,8 @@ main .hero-carousel .hero-carousel-nav {
 
 main .hero-carousel .hero-carousel-prev,
 main .hero-carousel .hero-carousel-next {
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border: none;
   border-radius: 50%;
   background: rgb(230 232 233);
@@ -262,16 +262,16 @@ main .hero-carousel .hero-carousel-dot:hover {
 @media (width >= 900px) {
   main .hero-carousel .hero-carousel-content {
     padding: 60px 0 96px;
-    margin-left: 64px;
+    margin-left: 120px;
   }
 
   main .hero-carousel .hero-carousel-content h1 {
-    font-size: 80px;
+    font-size: 96px;
     font-weight: 700;
     font-stretch: 75%;
     letter-spacing: 1.6px;
-    line-height: 80px;
-    max-width: 556px;
+    line-height: 96px;
+    max-width: 640px;
   }
 
   main .hero-carousel .hero-carousel-content p {
@@ -281,7 +281,7 @@ main .hero-carousel .hero-carousel-dot:hover {
   }
 
   main .hero-carousel .hero-carousel-nav {
-    left: 64px;
+    left: 120px;
     padding: 32px 0 29px;
   }
 }

--- a/blocks/news-carousel/news-carousel.css
+++ b/blocks/news-carousel/news-carousel.css
@@ -210,7 +210,7 @@ main .news-carousel .news-carousel-explore:hover {
 @media (width >= 900px) {
   main .news-carousel .news-carousel-card {
     flex: 0 0 calc((100% - 4 * var(--spacing-m)) / 5);
-    min-width: 200px;
+    min-width: 280px;
   }
 
   main .news-carousel .news-carousel-btn {


### PR DESCRIPTION
## Summary
Tunes layout and sizing for 1920x1080+ desktop resolution to match the original HPE site.

### Header
- Max-width 1264px → 1680px with 120px edge padding (logo far-left, tools far-right)
- Nav links right-aligned instead of centered
- Link padding increased (14px → 22px horizontal) for proper spacing

### Hero Carousel
- Content left margin 64px → 120px
- H1: 80px → 96px font-size, max-width 556px → 640px
- CTA button: larger padding (18px 36px) and font (20px)
- Nav arrows: 40px → 48px diameter, repositioned to 120px left

### News Carousel
- Card min-width 200px → 280px for proper sizing at wide viewports

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-desktop-1920-parity--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] At 1920x1080: header logo far-left, nav links right-aligned with proper spacing, tools far-right
- [ ] Hero H1 is ~96px, content indented ~120px from left edge
- [ ] Hero CTA button is larger with proper padding
- [ ] Nav arrows are 48px at the 120px left position
- [ ] News cards are ~280px+ wide at 1920px
- [ ] Still works at 1280px and 900px breakpoints
- [ ] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)