### PR TITLE
fix: Desktop parity R2 — white strip, padding, news cards, Miami badge

### DIFF
--- a/blocks/header/header-tokens.css
+++ b/blocks/header/header-tokens.css
@@ -6,7 +6,7 @@
   --header-nav-padding-desktop: 0 var(--content-inset);
   --header-nav-gap: 24px;
   --header-nav-gap-desktop: 32px;
-  --header-brand-width: 64px;
+  --header-brand-width: 104px;
   --header-dropdown-width: 200px;
   --header-dropdown-padding: 16px;
   --header-dropdown-left: -24px;

--- a/blocks/header/header-tokens.css
+++ b/blocks/header/header-tokens.css
@@ -3,7 +3,7 @@
   --header-nav-max-width: 1248px;
   --header-nav-max-width-desktop: 1680px;
   --header-nav-padding: 0 24px;
-  --header-nav-padding-desktop: 0 120px;
+  --header-nav-padding-desktop: 0 var(--content-inset);
   --header-nav-gap: 24px;
   --header-nav-gap-desktop: 32px;
   --header-brand-width: 64px;

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -24,7 +24,7 @@ main .hero-carousel .hero-carousel-slides {
   position: relative;
   width: 100%;
   overflow: hidden;
-  height: clamp(420px, calc(100vh - var(--nav-height)), 900px);
+  height: clamp(420px, calc(100vh - 66px), 900px);
 }
 
 /* ===== SLIDE: all absolute — avoids layout shift during crossfade ===== */

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -24,7 +24,7 @@ main .hero-carousel .hero-carousel-slides {
   position: relative;
   width: 100%;
   overflow: hidden;
-  height: clamp(420px, calc(100vh - 80px), 900px);
+  height: clamp(420px, calc(100vh - var(--nav-height)), 900px);
 }
 
 /* ===== SLIDE: all absolute — avoids layout shift during crossfade ===== */
@@ -82,6 +82,25 @@ main .hero-carousel .hero-carousel-slide::after {
     transparent 75%
   );
   pointer-events: none;
+}
+
+/* ===== FOREGROUND OVERLAY (badge/logo) ===== */
+main .hero-carousel .hero-carousel-fg-img {
+  position: absolute;
+  right: 5%;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 280px;
+  height: auto;
+  pointer-events: none;
+}
+
+@media (width < 900px) {
+  main .hero-carousel .hero-carousel-fg-img {
+    width: 160px;
+    right: 3%;
+  }
 }
 
 /* ===== CONTENT: relative, left-aligned, white text ===== */
@@ -262,7 +281,7 @@ main .hero-carousel .hero-carousel-dot:hover {
 @media (width >= 900px) {
   main .hero-carousel .hero-carousel-content {
     padding: 60px 0 96px;
-    margin-left: 120px;
+    margin-left: var(--content-inset);
   }
 
   main .hero-carousel .hero-carousel-content h1 {
@@ -281,7 +300,7 @@ main .hero-carousel .hero-carousel-dot:hover {
   }
 
   main .hero-carousel .hero-carousel-nav {
-    left: 120px;
+    left: var(--content-inset);
     padding: 32px 0 29px;
   }
 }

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -61,6 +61,18 @@ function decorateSlide(slide, index) {
       }
     });
   }
+
+  // Check for a foreground overlay image (e.g. badge/logo) matching the bg image
+  const bgImg = slide.querySelector('.hero-carousel-bg-img');
+  if (bgImg && bgImg.src.includes('background')) {
+    const fgSrc = bgImg.src.replace('background', 'foreground').replace('.jpg', '.png');
+    const fgImg = document.createElement('img');
+    fgImg.src = fgSrc;
+    fgImg.alt = '';
+    fgImg.className = 'hero-carousel-fg-img';
+    fgImg.loading = 'lazy';
+    slide.append(fgImg);
+  }
 }
 
 export default async function decorate(block) {

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -71,6 +71,8 @@ function decorateSlide(slide, index) {
     fgImg.alt = '';
     fgImg.className = 'hero-carousel-fg-img';
     fgImg.loading = 'lazy';
+    fgImg.width = 280;
+    fgImg.height = 280;
     slide.append(fgImg);
   }
 }

--- a/blocks/news-carousel/news-carousel.css
+++ b/blocks/news-carousel/news-carousel.css
@@ -29,28 +29,22 @@ main .news-carousel .news-carousel-track::-webkit-scrollbar {
   display: none;
 }
 
-/* Individual card */
+/* Individual card — no background, borderless like original */
 main .news-carousel .news-carousel-card {
   flex: 0 0 280px;
   min-width: 280px;
-  background-color: var(--dark-alt-color);
-  border-radius: 12px;
-  overflow: hidden;
+  background-color: transparent;
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
-  transition: transform var(--transition-base);
 }
 
-main .news-carousel .news-carousel-card:hover {
-  transform: translateY(-2px);
-}
-
-/* Card image — wider aspect ratio matching source */
+/* Card image — taller aspect ratio matching original */
 main .news-carousel .news-carousel-card-image {
   width: 100%;
-  aspect-ratio: 16 / 10;
+  aspect-ratio: 4 / 3;
   overflow: hidden;
+  border-radius: 8px;
 }
 
 main .news-carousel .news-carousel-card-image picture {
@@ -99,14 +93,32 @@ main .news-carousel .news-carousel-card-cta-wrap {
 
 main .news-carousel .news-carousel-card-cta {
   color: var(--color-hpe-green);
-  font-size: var(--body-font-size-xs);
+  font-size: var(--body-font-size-s);
   font-weight: 500;
   text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+main .news-carousel .news-carousel-card-cta::after {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-color: var(--color-hpe-green);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  transition: transform 0.2s;
 }
 
 main .news-carousel .news-carousel-card-cta:hover {
   color: var(--color-hpe-green-hover);
-  text-decoration: underline;
+}
+
+main .news-carousel .news-carousel-card-cta:hover::after {
+  transform: translateX(4px);
 }
 
 /* === Control bar: nav buttons (left) + explore link (right) === */
@@ -174,8 +186,10 @@ main .news-carousel .news-carousel-btn-next::after {
 
 /* Explore more news link */
 main .news-carousel .news-carousel-explore {
-  display: inline-block;
-  padding: 10px 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 28px;
   border: 2px solid var(--color-hpe-green);
   border-radius: var(--button-border-radius);
   color: var(--text-light-color);
@@ -186,10 +200,26 @@ main .news-carousel .news-carousel-explore {
   background-color: transparent;
 }
 
+main .news-carousel .news-carousel-explore::after {
+  content: '';
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  background-color: var(--text-light-color);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  transition: transform 0.2s;
+}
+
 main .news-carousel .news-carousel-explore:hover {
   background-color: var(--color-hpe-green);
   color: var(--text-light-color);
   text-decoration: none;
+}
+
+main .news-carousel .news-carousel-explore:hover::after {
+  transform: translateX(4px);
 }
 
 /* === Mobile: show ~1.3 cards === */

--- a/icons/hpe-logo.svg
+++ b/icons/hpe-logo.svg
@@ -1,12 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 40" fill="none">
-  <!-- Green geometric mark -->
-  <g fill="#01a982">
-    <path d="M26.2 0H20.2L13.9 8.2h6L26.2 0zM19.6 12H13.7L7.3 20.2h6L19.6 12zM13.1 8.2H7.1L.8 16.4h6l6.3-8.2zM32.7 3.8H26.8L20.5 12h6L32.7 3.8z"/>
-  </g>
-  <!-- White HPE text -->
-  <g fill="#ffffff">
-    <path d="M48.5 8.2h3.8v9h6.8v-9h3.8v22.6h-3.8v-10h-6.8v10h-3.8V8.2z"/>
-    <path d="M66.2 8.2h8.4c4.2 0 6.4 2.8 6.4 6.4 0 3.6-2.2 6.4-6.4 6.4h-4.6v9.8h-3.8V8.2zm3.8 9.6h4c2 0 3.2-1.2 3.2-3.2s-1.2-3.2-3.2-3.2h-4v6.4z"/>
-    <path d="M83.6 8.2H96v3.2h-8.6v6h7.4v3.2h-7.4v7h8.6v3.2H83.6V8.2z"/>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 180" fill="none">
+  <title>Hewlett Packard Enterprise</title>
+  <!-- H -->
+  <path d="M18 180 V0" stroke="white" stroke-width="36"/>
+  <path d="M172 180 V0" stroke="white" stroke-width="36"/>
+  <path d="M18 89 H155" stroke="white" stroke-width="36"/>
+  <!-- P -->
+  <path d="M250 180 V0" stroke="white" stroke-width="36"/>
+  <path d="M250 18 H352 A32 32 0 0 1 352 118 H250" stroke="white" stroke-width="36" fill="none"/>
+  <!-- E top + vertical -->
+  <path d="M472 51 V18 H630" stroke="white" stroke-width="36"/>
+  <!-- E bottom half (green) -->
+  <path d="M630 162 H472 V86 H630" stroke="#01a982" stroke-width="36"/>
 </svg>

--- a/icons/hpe-logo.svg
+++ b/icons/hpe-logo.svg
@@ -1,3 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 36" fill="#01a982">
-  <path d="M46.7 0H36.1L24.8 14.6h10.6L46.7 0zM35 21.4H24.4L13.1 36h10.6L35 21.4zM23.3 14.6H12.7L1.4 29.2h10.6l11.3-14.6zM58.4 6.8H47.8L36.5 21.4h10.6L58.4 6.8z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 40" fill="none">
+  <!-- Green geometric mark -->
+  <g fill="#01a982">
+    <path d="M26.2 0H20.2L13.9 8.2h6L26.2 0zM19.6 12H13.7L7.3 20.2h6L19.6 12zM13.1 8.2H7.1L.8 16.4h6l6.3-8.2zM32.7 3.8H26.8L20.5 12h6L32.7 3.8z"/>
+  </g>
+  <!-- White HPE text -->
+  <g fill="#ffffff">
+    <path d="M48.5 8.2h3.8v9h6.8v-9h3.8v22.6h-3.8v-10h-6.8v10h-3.8V8.2z"/>
+    <path d="M66.2 8.2h8.4c4.2 0 6.4 2.8 6.4 6.4 0 3.6-2.2 6.4-6.4 6.4h-4.6v9.8h-3.8V8.2zm3.8 9.6h4c2 0 3.2-1.2 3.2-3.2s-1.2-3.2-3.2-3.2h-4v6.4z"/>
+    <path d="M83.6 8.2H96v3.2h-8.6v6h7.4v3.2h-7.4v7h8.6v3.2H83.6V8.2z"/>
+  </g>
 </svg>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -67,7 +67,7 @@
   /* ===== LAYOUT ===== */
   --max-width-site: 1200px;
   --nav-height: 66px;
-  --content-inset: 160px;
+  --content-inset: 120px;
   --header-height: var(--nav-height);
 
   /* ===== BUTTONS ===== */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -66,7 +66,8 @@
 
   /* ===== LAYOUT ===== */
   --max-width-site: 1200px;
-  --nav-height: 80px;
+  --nav-height: 66px;
+  --content-inset: 120px;
   --header-height: var(--nav-height);
 
   /* ===== BUTTONS ===== */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -67,7 +67,7 @@
   /* ===== LAYOUT ===== */
   --max-width-site: 1200px;
   --nav-height: 66px;
-  --content-inset: 120px;
+  --content-inset: 160px;
   --header-height: var(--nav-height);
 
   /* ===== BUTTONS ===== */


### PR DESCRIPTION
## Summary
Consolidated fix for 4 visual parity issues identified at 1920x1080.

### White strip between header and hero (#68)
- `--nav-height` corrected from 80px to 66px (actual rendered height)
- Hero height calc uses `var(--nav-height)` instead of hardcoded value

### Hero left padding alignment (#66)
- New global `--content-inset: 120px` token ensures consistent alignment
- Header padding, hero content margin, and nav arrows all reference this token
- Stays consistent regardless of viewport width

### News carousel card styling (#67)
- Removed dark card backgrounds — cards sit directly on dark section
- Image aspect ratio changed to 4:3 (taller, matching original)
- Images have border-radius, no card container
- CTA links styled green with arrow icons
- "Explore more news" button has arrow icon

### Hero slide 2 Miami badge (#69)
- JS auto-detects foreground overlay images by naming convention
- Badge positioned absolutely on right side, vertically centered
- 280px desktop, 160px mobile

## Test URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-desktop-parity-r2--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] No white strip between header and hero
- [ ] Hero content left margin matches header logo position (~120px)
- [ ] News cards: no dark background, rounded images, green CTA arrows
- [ ] Slide 2: Miami CF badge visible on right side of stadium image
- [ ] All sections look correct at 1920x1080
- [ ] No lint errors

Closes #66, #67, #68, #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)