### PR TITLE
Fix #71: Increase global max-width to 1920px with 160px desktop padding

### DIFF
--- a/blocks/header/header-tokens.css
+++ b/blocks/header/header-tokens.css
@@ -1,9 +1,9 @@
 /* header design tokens (layout only; colors/typography use global tokens) */
 :root {
   --header-nav-max-width: 1248px;
-  --header-nav-max-width-desktop: 1680px;
+  --header-nav-max-width-desktop: var(--max-width-site);
   --header-nav-padding: 0 24px;
-  --header-nav-padding-desktop: 0 var(--content-inset);
+  --header-nav-padding-desktop: 0 var(--content-padding, 160px);
   --header-nav-gap: 24px;
   --header-nav-gap-desktop: 32px;
   --header-brand-width: 104px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -65,7 +65,8 @@
   --spacing-section: 80px;
 
   /* ===== LAYOUT ===== */
-  --max-width-site: 1200px;
+  --max-width-site: 1920px;
+  --content-padding: 24px;
   --nav-height: 66px;
   --content-inset: 120px;
   --header-height: var(--nav-height);
@@ -117,6 +118,7 @@
     --heading-font-size-m: 24px;
     --heading-font-size-s: 20px;
     --heading-font-size-xs: 16px;
+    --content-padding: 160px;
   }
 }
 
@@ -354,7 +356,7 @@ main > .section {
 main > .section > div:not(.bg-image) {
   max-width: var(--max-width-site);
   margin: auto;
-  padding: 0 24px;
+  padding: 0 var(--content-padding);
 }
 
 main > .section:first-of-type {
@@ -393,7 +395,7 @@ main > .section > .bg-image img {
 
 @media (width >= 900px) {
   main > .section > div:not(.bg-image) {
-    padding: 0 32px;
+    padding: 0 var(--content-padding);
   }
 
   main > .section {


### PR DESCRIPTION
## Summary
- Increases `--max-width-site` from `1200px` to `1920px` to match original HPE site
- Adds `--content-padding` variable: `24px` mobile, `160px` desktop (matching original's `padding: 0 160px`)
- Updates header nav to use the new global max-width and padding tokens
- Effective content width at desktop: **1600px** (matching original exactly)

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-71-global-max-width--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify content width at 1920x1080
- [ ] Verify content width at 1728x1117
- [ ] Verify content width at 3440x1440 (most impactful change visible here)
- [ ] Confirm nav spans properly at all resolutions
- [ ] Confirm no section overflows or horizontal scrollbar

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)