### PR TITLE
Fix #73: Remove hero carousel dot indicators

### DIFF
--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -229,33 +229,6 @@ main .hero-carousel .hero-carousel-next::after {
   transform: rotate(45deg) translate(-2px, 2px);
 }
 
-/* ===== SLIDE INDICATORS (dots) ===== */
-main .hero-carousel .hero-carousel-indicators {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-left: 12px;
-}
-
-main .hero-carousel .hero-carousel-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 2px solid rgb(230 232 233);
-  background: transparent;
-  padding: 0;
-  cursor: pointer;
-  transition: background 0.2s, border-color 0.2s;
-}
-
-main .hero-carousel .hero-carousel-dot.active {
-  background: rgb(230 232 233);
-}
-
-main .hero-carousel .hero-carousel-dot:hover {
-  border-color: white;
-}
-
 /* ===== TABLET (600px+) ===== */
 @media (width >= 600px) {
   main .hero-carousel .hero-carousel-content {

--- a/blocks/hero-carousel/hero-carousel.js
+++ b/blocks/hero-carousel/hero-carousel.js
@@ -105,19 +105,10 @@ export default async function decorate(block) {
     }
   }
 
-  function updateIndicators() {
-    const dots = block.querySelectorAll('.hero-carousel-dot');
-    dots.forEach((dot, i) => {
-      dot.classList.toggle('active', i === current);
-      dot.setAttribute('aria-selected', i === current ? 'true' : 'false');
-    });
-  }
-
   function goTo(index) {
     slides[current].classList.remove('active');
     current = (index + slides.length) % slides.length;
     slides[current].classList.add('active');
-    updateIndicators();
   }
 
   function startAutoplay() {
@@ -138,23 +129,7 @@ export default async function decorate(block) {
   nextBtn.setAttribute('aria-label', 'Next');
   nextBtn.addEventListener('click', () => { goTo(current + 1); startAutoplay(); });
 
-  // Slide indicators (dots)
-  const indicators = document.createElement('div');
-  indicators.className = 'hero-carousel-indicators';
-  indicators.setAttribute('role', 'tablist');
-
-  slides.forEach((_, i) => {
-    const dot = document.createElement('button');
-    dot.className = 'hero-carousel-dot';
-    if (i === 0) dot.classList.add('active');
-    dot.setAttribute('role', 'tab');
-    dot.setAttribute('aria-label', `Slide ${i + 1}`);
-    dot.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
-    dot.addEventListener('click', () => { goTo(i); startAutoplay(); });
-    indicators.append(dot);
-  });
-
-  nav.append(prevBtn, nextBtn, indicators);
+  nav.append(prevBtn, nextBtn);
   block.append(nav);
 
   startAutoplay();


### PR DESCRIPTION
## Summary
- Removes dot indicator creation from hero-carousel.js
- Removes `updateIndicators()` function
- Removes all dot-related CSS (`.hero-carousel-indicators`, `.hero-carousel-dot`)
- Hero carousel now only has prev/next arrow buttons, matching the original HPE site

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-73-hero-remove-dots--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify no dot indicators appear below the hero carousel
- [ ] Verify prev/next arrow buttons still work
- [ ] Verify autoplay still cycles slides
- [ ] Test at 1920x1080, 1728x1117, 3440x1440

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)