### PR TITLE
Fix #75: Feature Banner — left-aligned, light bg, dark CTA

### DIFF
--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -1,71 +1,79 @@
-/* Feature Banner — dark promotional section with centered text and CTA */
+/* Feature Banner — left-aligned text section with dark pill CTA
+   Matches original HPE homepage "AI for every use case" and "HPE Services" sections */
+
+/* Override section dark-alt background — original renders these as light sections */
+main > .section.dark-alt:has(.feature-banner) {
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+main > .section.dark-alt:has(.feature-banner) h2,
+main > .section.dark-alt:has(.feature-banner) h3 {
+  color: var(--text-color);
+}
+
+main > .section.dark-alt:has(.feature-banner) p {
+  color: var(--text-secondary-color);
+}
 
 main .feature-banner {
-  background-color: var(--dark-alt-color);
   padding: var(--spacing-xl) 0;
-  text-align: center;
+  text-align: left;
 }
 
-main .feature-banner .feature-banner-inner {
-  max-width: var(--max-width-site);
-  margin: 0 auto;
-  padding: 0 var(--spacing-m);
-}
-
-main .feature-banner .feature-banner-inner > div {
-  margin-bottom: var(--spacing-s);
-}
-
-main .feature-banner .feature-banner-inner > div:last-child {
-  margin-bottom: 0;
+main .feature-banner > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
 }
 
 main .feature-banner h2,
 main .feature-banner h3 {
-  color: var(--text-light-color);
+  color: var(--text-color);
   font-size: var(--heading-font-size-xl);
-  margin-bottom: var(--spacing-s);
+  font-weight: 500;
+  margin: 0;
 }
 
 main .feature-banner p {
-  color: rgb(255 255 255 / 80%);
-  font-size: var(--body-font-size-m);
+  color: var(--text-secondary-color);
+  font-size: var(--body-font-size-l);
   line-height: 1.5;
-  margin-bottom: var(--spacing-s);
+  margin: 0;
 }
 
-/* CTA: white pill button with arrow — matches hero and source */
+/* CTA: dark pill button with arrow — matches original */
 main .feature-banner a.button,
-main .feature-banner .feature-banner-inner > div:last-child a {
+main .feature-banner a {
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  background-color: white;
-  color: var(--dark-color);
+  background-color: var(--dark-color);
+  color: var(--text-light-color);
   border: none;
   border-radius: 100px;
-  padding: 14px 28px;
-  font-size: var(--body-font-size-m);
+  padding: 20px 36px;
+  font-size: var(--body-font-size-l);
   font-weight: 500;
   text-decoration: none;
-  margin-top: var(--spacing-m);
   transition: background-color 0.2s;
+  width: fit-content;
 }
 
 main .feature-banner a.button:hover,
-main .feature-banner .feature-banner-inner > div:last-child a:hover {
-  background-color: #e5e5e5;
+main .feature-banner a:hover {
+  background-color: var(--text-color);
   text-decoration: none;
-  color: var(--dark-color);
+  color: var(--text-light-color);
 }
 
 main .feature-banner a.button::after,
-main .feature-banner .feature-banner-inner > div:last-child a::after {
+main .feature-banner a::after {
   content: '';
   display: inline-block;
   width: 14px;
   height: 14px;
-  background-color: var(--dark-color);
+  background-color: var(--text-light-color);
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
   /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
@@ -73,28 +81,22 @@ main .feature-banner .feature-banner-inner > div:last-child a::after {
 }
 
 main .feature-banner a.button:hover::after,
-main .feature-banner .feature-banner-inner > div:last-child a:hover::after {
+main .feature-banner a:hover::after {
   transform: translateX(4px);
-}
-
-/* Tablet */
-@media (width >= 600px) {
-  main .feature-banner {
-    padding: var(--spacing-xl) 0;
-  }
-
-  main .feature-banner .feature-banner-inner {
-    padding: 0 var(--spacing-l);
-  }
 }
 
 /* Desktop */
 @media (width >= 900px) {
   main .feature-banner {
-    padding: var(--spacing-xxl) 0;
+    padding: var(--spacing-section) 0;
   }
 
-  main .feature-banner .feature-banner-inner {
-    padding: 0 var(--spacing-l);
+  main .feature-banner h2,
+  main .feature-banner h3 {
+    font-size: 36px;
+  }
+
+  main .feature-banner p {
+    font-size: var(--body-font-size-l);
   }
 }


### PR DESCRIPTION
## Summary
- Overrides dark-alt section background to white/light for feature-banner sections (matching original)
- Changes text alignment from centered to left-aligned
- CTA button changed from white pill to dark pill with white text + arrow icon
- Heading size matched to original (36px desktop)
- Body text matched to original (20px, grey)

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-75-feature-banner--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify "AI for every use case" section has white/light background
- [ ] Verify text is left-aligned
- [ ] Verify CTA is dark pill button with white text and arrow
- [ ] Verify "HPE Services" section also renders correctly (uses same block)
- [ ] Test at 1920x1080, 1728x1117, 3440x1440

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)