### PR TITLE
Fix #77: Card Carousel — remove dots, gradient edges, larger cards

### DIFF
--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -193,37 +193,69 @@ main .card-carousel .carousel-navigation-buttons button.slide-next::after {
   left: calc(50% - 2px);
 }
 
-/* Dot indicators */
+/* Hide dot indicators — original has none */
 main .card-carousel .carousel-slide-indicators {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  justify-content: center;
-  gap: var(--spacing-xs);
-  margin-top: var(--spacing-m);
+  display: none;
 }
 
-/* stylelint-disable-next-line no-descending-specificity */
-main .card-carousel .carousel-slide-indicator button {
-  width: 10px;
-  height: 10px;
-  margin: 0;
-  padding: 0;
-  border-radius: 50%;
-  border: none;
-  background-color: rgb(255 255 255 / 30%);
-  cursor: pointer;
-  transition: background-color var(--transition-base);
+/* Gradient edge masks for smooth card reveal/disappear */
+main .card-carousel .card-carousel-slides {
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    black 8%,
+    black 92%,
+    transparent 100%
+  );
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    black 8%,
+    black 92%,
+    transparent 100%
+  );
 }
 
-main .card-carousel .carousel-slide-indicator button:hover {
-  background-color: rgb(255 255 255 / 60%);
+/* No left gradient when at start */
+main .card-carousel .card-carousel-slides.at-start {
+  mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black 92%,
+    transparent 100%
+  );
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black 92%,
+    transparent 100%
+  );
 }
 
-main .card-carousel .carousel-slide-indicator button:disabled {
-  background-color: var(--text-light-color);
-  cursor: default;
+/* No right gradient when at end */
+main .card-carousel .card-carousel-slides.at-end {
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    black 8%,
+    black 100%
+  );
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    black 8%,
+    black 100%
+  );
+}
+
+/* No gradients at all when at both start and end (few cards) */
+main .card-carousel .card-carousel-slides.at-start.at-end {
+  mask-image: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask-image: none;
 }
 
 /* === Mobile: 1 card visible === */
@@ -250,8 +282,8 @@ main .card-carousel .carousel-slide-indicator button:disabled {
 /* === Desktop: 2 cards visible with peek === */
 @media (width >= 900px) {
   main .card-carousel .card-carousel-slide {
-    flex: 0 0 calc(50% - var(--spacing-s));
-    min-height: 480px;
+    flex: 0 0 calc(45% - var(--spacing-s));
+    min-height: 540px;
   }
 
   main .card-carousel .card-carousel-card-content {
@@ -277,6 +309,6 @@ main .card-carousel .carousel-slide-indicator button:disabled {
 /* === Wide desktop === */
 @media (width >= 1200px) {
   main .card-carousel .card-carousel-slide {
-    min-height: 520px;
+    min-height: 560px;
   }
 }

--- a/blocks/card-carousel/card-carousel.js
+++ b/blocks/card-carousel/card-carousel.js
@@ -33,10 +33,9 @@ export default function decorate(block) {
   slidesWrapper.setAttribute('aria-label', 'Card carousel slides');
 
   if (!isSingleSlide) {
-    const { indicatorsNav, buttonsContainer } = createSliderControls(rows.length, {
+    const { buttonsContainer } = createSliderControls(rows.length, {
       indicatorsAriaLabel: `Card Carousel Slide Controls for ${blockId}`,
     });
-    block.append(indicatorsNav);
     container.append(buttonsContainer);
   }
 
@@ -133,5 +132,17 @@ export default function decorate(block) {
       const next = e.key === 'ArrowLeft' ? current - 1 : current + 1;
       showSlide(block, next, 'smooth', sliderOpts);
     });
+
+    // Gradient edge masks — toggle based on scroll position
+    function updateGradientMasks() {
+      const { scrollLeft, scrollWidth, clientWidth } = slidesWrapper;
+      const atStart = scrollLeft <= 2;
+      const atEnd = scrollLeft + clientWidth >= scrollWidth - 2;
+      slidesWrapper.classList.toggle('at-start', atStart);
+      slidesWrapper.classList.toggle('at-end', atEnd);
+    }
+
+    slidesWrapper.addEventListener('scroll', updateGradientMasks, { passive: true });
+    updateGradientMasks();
   }
 }


### PR DESCRIPTION
## Summary
- Removes dot indicators (original HPE carousel has none)
- Adds CSS mask-image gradient on left/right edges for smooth card reveal/disappear effect
- Gradient visibility toggles via JS: no left gradient at start, no right gradient at end
- Increases card min-height (540px desktop, 560px wide) and width (45% for ~2.2 visible)

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-77-card-carousel--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify no dot indicators below the card carousel
- [ ] Verify gradient fade effect on edges when scrolling
- [ ] Verify no left gradient when at first card
- [ ] Verify no right gradient when at last card
- [ ] Verify cards are taller and show ~2.2 at desktop
- [ ] Test at 1920x1080, 1728x1117, 3440x1440

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)