### PR TITLE
Fix #78: Product Cards — image display, rounded corners, arrow CTA

### DIFF
--- a/blocks/product-cards/product-cards.css
+++ b/blocks/product-cards/product-cards.css
@@ -1,4 +1,4 @@
-/* Product Cards — grid of product category cards */
+/* Product Cards — grid of product category cards matching original HPE */
 
 main .product-cards {
   display: grid;
@@ -13,7 +13,7 @@ main .product-cards .product-card {
   flex-direction: column;
   background-color: var(--background-color);
   border: 1px solid var(--border-light-color);
-  border-radius: 8px;
+  border-radius: 12px;
   overflow: hidden;
   transition: box-shadow var(--transition-slow), transform var(--transition-slow);
 }
@@ -23,22 +23,24 @@ main .product-cards .product-card:hover {
   transform: translateY(-2px);
 }
 
-/* Card image */
+/* Card image — ensure picture and img fill properly */
 main .product-cards .product-card-image {
   width: 100%;
   overflow: hidden;
+  background-color: var(--light-color);
 }
 
 main .product-cards .product-card-image picture {
   display: block;
   width: 100%;
-  aspect-ratio: 3 / 2;
+  height: 100%;
 }
 
 main .product-cards .product-card-image img {
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
+  aspect-ratio: 3 / 2;
   object-fit: cover;
   transition: transform 0.6s ease;
 }
@@ -53,11 +55,11 @@ main .product-cards .product-card-content {
   flex-direction: column;
   flex: 1;
   padding: var(--spacing-m);
-  gap: var(--spacing-s);
+  gap: var(--spacing-xs);
 }
 
 main .product-cards .product-card-content h3 {
-  font-size: var(--heading-font-size-l);
+  font-size: var(--heading-font-size-m);
   font-weight: 500;
   color: var(--text-color);
   margin: 0;
@@ -70,7 +72,7 @@ main .product-cards .product-card-content p {
   margin: 0;
 }
 
-/* CTA link */
+/* CTA link with green arrow */
 main .product-cards .product-card-cta {
   margin-top: auto;
   padding-top: var(--spacing-s);
@@ -79,20 +81,24 @@ main .product-cards .product-card-cta {
 main .product-cards .product-card-link {
   color: var(--color-hpe-green);
   font-size: var(--body-font-size-s);
-  font-weight: 600;
+  font-weight: 500;
   text-decoration: none;
-  display: inline;
-  line-height: 1.6;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   transition: color var(--transition-base);
 }
 
 main .product-cards .product-card-link::after {
-  content: '\2192';
+  content: '';
   display: inline-block;
-  margin-left: 6px;
-  font-size: 1.1em;
-  transition: transform var(--transition-base);
-  vertical-align: middle;
+  width: 12px;
+  height: 12px;
+  background-color: var(--color-hpe-green);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  transition: transform 0.2s;
 }
 
 main .product-cards .product-card-link:hover {
@@ -101,10 +107,11 @@ main .product-cards .product-card-link:hover {
 }
 
 main .product-cards .product-card-link:hover::after {
+  background-color: var(--color-hpe-green-hover);
   transform: translateX(4px);
 }
 
-/* Tablet: 2 columns for two-up, 2 columns for three-up */
+/* Tablet: 2 columns */
 @media (width >= 600px) {
   main .product-cards.two-up {
     grid-template-columns: repeat(2, 1fr);
@@ -127,5 +134,6 @@ main .product-cards .product-card-link:hover::after {
 
   main .product-cards .product-card-content {
     padding: var(--spacing-l);
+    gap: var(--spacing-s);
   }
 }


### PR DESCRIPTION
## Summary
- Fix picture/img element sizing to properly display product images
- Add light grey background fallback during image loading
- Increase border-radius to 12px matching original
- CTA link updated to use SVG mask arrow (consistent with other blocks)
- Refined card content spacing

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-78-product-cards--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify product images display correctly (not grey boxes)
- [ ] Verify 2-up grid (Networking, Software) at desktop
- [ ] Verify 3-up grid (Storage, Compute, Supercomputing) at desktop
- [ ] Verify green CTA arrows and hover effects
- [ ] Test at 1920x1080, 1728x1117, 3440x1440

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)