### PR TITLE
Fix #80 #81: GreenLake screenshot shadow, HPE Services gradient

### DIFF
--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -98,3 +98,31 @@ main .feature-banner .feature-banner-inner > div:last-child a:hover::after {
     padding: 0 var(--spacing-l);
   }
 }
+
+/* Teal gradient accent for HPE Services feature-banner (has h2 heading) */
+main .feature-banner:has(h2)::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 40%;
+  background: linear-gradient(
+    135deg,
+    transparent 0%,
+    rgb(1 169 130 / 15%) 50%,
+    rgb(1 169 130 / 30%) 100%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+main > .section:has(.feature-banner:has(h2)) {
+  position: relative;
+  overflow: hidden;
+}
+
+main .feature-banner:has(h2) .feature-banner-inner {
+  position: relative;
+  z-index: 1;
+}

--- a/blocks/greenlake-promo/greenlake-promo.css
+++ b/blocks/greenlake-promo/greenlake-promo.css
@@ -158,6 +158,7 @@ main .greenlake-promo .greenlake-promo-screenshot img {
   width: 100%;
   height: auto;
   border-radius: 8px;
+  box-shadow: 0 8px 32px rgb(0 0 0 / 30%);
 }
 
 main .greenlake-promo .greenlake-promo-heading {


### PR DESCRIPTION
## Summary
- **HPE Services (Issue #81):** Adds teal gradient accent on the right edge of the section, matching original. Uses CSS ::after pseudo-element on the feature-banner that contains an h2 heading.
- **GreenLake Promo (Issue #80):** Adds box-shadow to the screenshot image for visual depth matching original.

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-80-81-greenLake-services--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify HPE Services section has teal gradient accent on right side
- [ ] Verify gradient doesn't appear on the "AI for every use case" feature-banner
- [ ] Verify GreenLake screenshot has subtle shadow
- [ ] Test at 1920x1080, 1728x1117, 3440x1440

Fixes #80, Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)