### PR TITLE
Fix #82: Footer padding aligned with global content layout

### DIFF
--- a/blocks/footer/footer-tokens.css
+++ b/blocks/footer/footer-tokens.css
@@ -1,6 +1,6 @@
 /* footer design tokens */
 :root {
-  --footer-max-width: var(--max-width-site);
+  --footer-max-width: var(--max-width-site, 1920px);
   --footer-padding: 40px 24px 24px;
-  --footer-padding-desktop: 40px 32px 24px;
+  --footer-padding-desktop: 40px var(--content-padding, 160px) 24px;
 }


### PR DESCRIPTION
## Summary
- Footer desktop padding updated to use `--content-padding` (160px) instead of hardcoded 32px
- Footer max-width uses `--max-width-site` (1920px) with fallback
- Ensures footer content alignment matches all other page sections

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-82-footer--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify footer content alignment matches other sections
- [ ] Verify footer is properly spaced at all 3 resolutions
- [ ] Verify no content overflow at 3440x1440

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)