### PR TITLE
Fix: Global desktop H2 font-size 40px → 52px

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -113,7 +113,7 @@
 @media (width >= 900px) {
   :root {
     --heading-font-size-xxl: 80px;
-    --heading-font-size-xl: 40px;
+    --heading-font-size-xl: 52px;
     --heading-font-size-l: 32px;
     --heading-font-size-m: 24px;
     --heading-font-size-s: 20px;


### PR DESCRIPTION
## Summary
- `--heading-font-size-xl` changed from `40px` to `52px` at desktop (900px+)
- Original HPE uses 52px for ALL H2 headings (Latest news, Solutions grid, Customer stories, Products, HPE Services)
- Verified via computed styles at 1728×1117

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://issue-h-h2-fontsize-52--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] All H2 headings render at 52px at desktop
- [ ] No overflow or layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)