### PR TITLE
Fix: Nav height 80px, white icons, flex layout, hero btn 56px

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -220,13 +220,22 @@ header nav .nav-tools-search .icon {
   color: rgb(212 212 212);
 }
 
+/* Handle both inline SVG and img-based icons */
 header nav .nav-tools-search .icon svg {
   fill: currentcolor;
   stroke: currentcolor;
 }
 
+header nav .nav-tools-search .icon img {
+  filter: brightness(0) invert(0.85);
+}
+
 header nav .nav-tools-search:hover .icon {
   color: var(--text-light-color);
+}
+
+header nav .nav-tools-search:hover .icon img {
+  filter: brightness(0) invert(1);
 }
 
 header nav .nav-tools-lang {
@@ -277,6 +286,7 @@ header nav .nav-tools-lang:hover {
   }
 
   header nav[aria-expanded='true'] .nav-sections {
+    display: flex;
     align-self: unset;
     padding-top: 0;
   }
@@ -341,8 +351,16 @@ header nav .nav-tools-lang:hover {
     stroke: currentcolor;
   }
 
+  header nav .nav-tools-lang .icon img {
+    filter: brightness(0) invert(0.85);
+  }
+
   header nav .nav-tools-lang:hover .icon {
     color: var(--text-light-color);
+  }
+
+  header nav .nav-tools-lang:hover .icon img {
+    filter: brightness(0) invert(1);
   }
 
   /* Dropdown buttons */

--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -190,8 +190,8 @@ main .hero-carousel .hero-carousel-nav {
 
 main .hero-carousel .hero-carousel-prev,
 main .hero-carousel .hero-carousel-next {
-  width: 48px;
-  height: 48px;
+  width: 56px;
+  height: 56px;
   border: none;
   border-radius: 50%;
   background: rgb(230 232 233);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -67,7 +67,7 @@
   /* ===== LAYOUT ===== */
   --max-width-site: 1920px;
   --content-padding: 24px;
-  --nav-height: 66px;
+  --nav-height: 80px;
   --content-inset: 120px;
   --header-height: var(--nav-height);
 


### PR DESCRIPTION
## Summary
- Nav height: 66px → 80px
- Icon colors: CSS filter `brightness(0) invert(0.85)` for img-based SVG icons
- Nav sections: fix specificity so desktop flex layout wins over mobile block
- Hero nav buttons: 48px → 56px

## Comparison URLs
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://issue-a-nav-height-icons-flex--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Nav bar visually taller (80px)
- [ ] Search and globe icons appear white
- [ ] Nav links align right (flex-end)
- [ ] Hero prev/next buttons are 56px circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)