### PR TITLE
Fix #102: Nav height 80px — desktop rule missing explicit height

### DIFF
--- a/blocks/customer-stories/customer-stories.css
+++ b/blocks/customer-stories/customer-stories.css
@@ -140,8 +140,8 @@ main .customer-stories .customer-stories-panel[aria-hidden='true'] {
   }
 }
 
-/* ===== BENTO GRID PANEL (matches original uc-cs-slide-layout) ===== */
-/* Original: 10-column, 2-row CSS Grid, gap 32px, horizontally scrollable.
+/* ===== BENTO GRID PANEL (matches original uc-cs-slide-layout) =====
+   Original: 10-column, 2-row CSS Grid, gap 32px, horizontally scrollable.
    11 tiles alternating text (dark/white bg) and image tiles.
    borderRadius: 0 on all tiles, overflow: clip. */
 

--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -16,8 +16,8 @@ main > .section.dark-alt:has(.feature-banner:has(h3)) p {
   color: var(--text-secondary-color);
 }
 
-/* === DARK VARIANT (h2-based, e.g. "HPE Services") === */
-/* Dark-alt section keeps its background; add teal gradient accent */
+/* === DARK VARIANT (h2-based, e.g. "HPE Services") ===
+   Dark-alt section keeps its background; add teal gradient accent */
 main > .section.dark-alt:has(.feature-banner:has(h2)) {
   position: relative;
   overflow: hidden;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -260,10 +260,12 @@ header nav .nav-tools-lang:hover {
     align-items: center;
     gap: 0;
     max-width: var(--header-nav-max-width-desktop);
+    height: var(--nav-height);
     padding: var(--header-nav-padding-desktop);
   }
 
   header nav[aria-expanded='true'] {
+    height: var(--nav-height);
     min-height: 0;
     overflow: visible;
   }


### PR DESCRIPTION
## Summary

### Root cause (verified via devtools)
The mobile rule \`header nav[aria-expanded='true']\` sets \`height: auto\` for the mobile expanded menu. On desktop, \`aria-expanded\` is set to \`true\` by the JS. The desktop media query rule \`header nav\` switches to \`display: flex\` but **never re-declares \`height\`**. Since \`nav[aria-expanded='true']\` has higher specificity than \`nav\`, the mobile \`height: auto\` wins — collapsing the nav to content height (~66px instead of 80px).

### Fix
Added explicit \`height: var(--nav-height)\` to both:
1. Desktop \`header nav\` rule
2. Desktop \`header nav[aria-expanded='true']\` rule

### Icon color status
Icon colors were confirmed **working** during investigation. CSS \`filter: brightness(0) invert(0.85)\` is being applied to the \`<img>\` elements and renders icons as light grey. The earlier audit reading of \`rgb(0,0,0)\` was the SVG source \`fill\` attribute, not the rendered appearance. Screenshot evidence captured. **No icon fix needed.**

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-1-nav-height-icon-color--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Nav computed height is 80px at 1728×1117
- [ ] Nav computed height is 80px at 3440×1440
- [ ] Nav visual appearance matches original (icons still light grey)
- [ ] Mobile nav still opens/closes correctly (aria-expanded toggle)

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)