### PR TITLE
Fix #105: Feature Banner — JS variant classes, fix nested :has() failure

### DIFF
--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -1,34 +1,35 @@
-/* Feature Banner — two variants:
-   1. "AI for every use case" (h3) — light bg, dark text, dark pill CTA
-   2. "HPE Services" (h2) — dark bg, white text, white pill CTA, teal gradient */
+/* Feature Banner — two variants determined by JS-applied section classes:
+   .feature-banner-light (h3) — "AI for every use case" — white bg, dark text, dark pill CTA
+   .feature-banner-dark (h2) — "HPE Services" — dark-alt bg, white text, white pill CTA, teal gradient
+   Note: nested :has() is invalid in CSS — variants use JS-applied classes instead. */
 
-/* === LIGHT VARIANT (h3-based, e.g. "AI for every use case") === */
-main > .section.dark-alt:has(.feature-banner:has(h3)) {
+/* === LIGHT VARIANT (.feature-banner-light on section) === */
+main > .section.feature-banner-light {
   background-color: var(--background-color);
   color: var(--text-color);
 }
 
-main > .section.dark-alt:has(.feature-banner:has(h3)) h3 {
+main > .section.feature-banner-light h3 {
   color: var(--text-color);
 }
 
-main > .section.dark-alt:has(.feature-banner:has(h3)) p {
+main > .section.feature-banner-light p {
   color: var(--text-secondary-color);
 }
 
-/* === DARK VARIANT (h2-based, e.g. "HPE Services") ===
-   Dark-alt section keeps its background; add teal gradient accent */
-main > .section.dark-alt:has(.feature-banner:has(h2)) {
+/* === DARK VARIANT (.feature-banner-dark on section) ===
+   Keeps dark-alt background; adds teal gradient accent */
+main > .section.feature-banner-dark {
   position: relative;
   overflow: hidden;
 }
 
-main .feature-banner:has(h2) .feature-banner-inner {
+main .section.feature-banner-dark .feature-banner-inner {
   position: relative;
   z-index: 1;
 }
 
-main .feature-banner:has(h2)::after {
+main .section.feature-banner-dark .feature-banner::after {
   content: '';
   position: absolute;
   top: 0;
@@ -45,29 +46,29 @@ main .feature-banner:has(h2)::after {
   z-index: 0;
 }
 
-main .feature-banner:has(h2) h2 {
+main .section.feature-banner-dark h2 {
   color: var(--text-light-color);
 }
 
-main .feature-banner:has(h2) p {
+main .section.feature-banner-dark p {
   color: rgb(255 255 255 / 80%);
 }
 
 /* HPE Services CTA: white pill with dark text + arrow */
-main .feature-banner:has(h2) a.button,
-main .feature-banner:has(h2) a {
+main .section.feature-banner-dark .feature-banner a.button,
+main .section.feature-banner-dark .feature-banner a {
   background-color: white;
   color: var(--dark-color);
 }
 
-main .feature-banner:has(h2) a.button:hover,
-main .feature-banner:has(h2) a:hover {
+main .section.feature-banner-dark .feature-banner a.button:hover,
+main .section.feature-banner-dark .feature-banner a:hover {
   background-color: #e5e5e5;
   color: var(--dark-color);
 }
 
-main .feature-banner:has(h2) a.button::after,
-main .feature-banner:has(h2) a::after {
+main .section.feature-banner-dark .feature-banner a.button::after,
+main .section.feature-banner-dark .feature-banner a::after {
   background-color: var(--dark-color);
 }
 
@@ -83,8 +84,15 @@ main .feature-banner > div {
   gap: var(--spacing-m);
 }
 
-main .feature-banner h2,
+/* H3 (light variant): 36px — matches original devtools value.
+   H2 (dark variant): uses --heading-font-size-xl (52px). */
 main .feature-banner h3 {
+  font-size: 36px;
+  font-weight: 500;
+  margin: 0;
+}
+
+main .feature-banner h2 {
   font-size: var(--heading-font-size-xl);
   font-weight: 500;
   margin: 0;

--- a/blocks/feature-banner/feature-banner.js
+++ b/blocks/feature-banner/feature-banner.js
@@ -1,5 +1,8 @@
 /**
  * Decorates the feature-banner block.
+ * Two variants determined by heading level:
+ *   h3 → light variant ("AI for every use case") — white bg, dark text
+ *   h2 → dark variant ("HPE Services") — keeps dark-alt bg, white text, teal gradient
  * @param {Element} block The feature-banner block element
  */
 export default async function decorate(block) {
@@ -12,4 +15,15 @@ export default async function decorate(block) {
   }
 
   block.append(inner);
+
+  // Determine variant by heading level and add class to section
+  // (CSS nested :has() is not supported — must use JS)
+  const section = block.closest('.section');
+  if (section) {
+    if (block.querySelector('h3')) {
+      section.classList.add('feature-banner-light');
+    } else if (block.querySelector('h2')) {
+      section.classList.add('feature-banner-dark');
+    }
+  }
 }


### PR DESCRIPTION
## Summary

### Root cause (confirmed via devtools)
CSS nested \`:has()\` — e.g. \`:has(.feature-banner:has(h3))\` — is **invalid syntax**. Browsers throw \`SyntaxError: not a valid selector\`. The entire CSS rule block was silently ignored, so:
- The "AI for every use case" section kept its \`dark-alt\` background (should be white)
- H3 inherited white color (should be dark)
- H3 inherited \`--heading-font-size-xl\` = 52px (should be 36px)

### Fix
**JS approach** (since CSS `:has()` nesting is not supported):
- \`feature-banner.js\` now detects the heading level and adds a class to the parent section:
  - \`h3\` → \`.feature-banner-light\` (white bg, dark text)
  - \`h2\` → \`.feature-banner-dark\` (dark-alt bg, teal gradient, white text)
- CSS rewritten to use \`.feature-banner-light\` / \`.feature-banner-dark\` classes
- H3 fontSize set to explicit \`36px\` (not the variable, which is 52px)

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-4-feature-banner-context--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] "AI for every use case" section has **white/light** background
- [ ] "AI for every use case" H3 is **dark text, 36px**
- [ ] "AI for every use case" CTA is **dark pill** with white text
- [ ] "HPE Services" section has **dark-alt** background with teal gradient
- [ ] "HPE Services" H2 is **white text, 52px**
- [ ] "HPE Services" CTA is **white pill** with dark text
- [ ] Verify at 1728×1117 and 3440×1440

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)