### PR TITLE
Fix #104: News Carousel — Explore CTA text visible, card sizing

### DIFF
--- a/blocks/news-carousel/news-carousel.css
+++ b/blocks/news-carousel/news-carousel.css
@@ -183,7 +183,9 @@ main .news-carousel .news-carousel-btn-next::after {
   left: calc(50% - 2px);
 }
 
-/* Explore more news — white pill button matching original */
+/* Explore more news — white pill button matching original.
+   Specificity must beat .section.dark a { color: white } */
+main .section.dark .news-carousel .news-carousel-explore,
 main .news-carousel .news-carousel-explore {
   display: inline-flex;
   align-items: center;
@@ -211,6 +213,7 @@ main .news-carousel .news-carousel-explore::after {
   transition: transform 0.2s;
 }
 
+main .section.dark .news-carousel .news-carousel-explore:hover,
 main .news-carousel .news-carousel-explore:hover {
   background-color: #e5e5e5;
   color: var(--dark-color);
@@ -239,7 +242,7 @@ main .news-carousel .news-carousel-explore:hover::after {
 @media (width >= 900px) {
   main .news-carousel .news-carousel-card {
     flex: 0 0 calc((100% - 4 * var(--spacing-m)) / 5);
-    min-width: 280px;
+    min-width: 0;
   }
 
   main .news-carousel .news-carousel-btn {


### PR DESCRIPTION
## Summary

### Fix 1: "Explore more news" CTA text invisible
The white pill button rendered correctly (bg, padding, borderRadius, fontSize all matched), but the **text was white-on-white** — invisible. Root cause: \`.section.dark a { color: white }\` from \`styles.css\` overrode the block-level \`color: var(--dark-color)\`. Fixed by adding a higher-specificity selector: \`main .section.dark .news-carousel .news-carousel-explore\`.

### Fix 2: Card height 689px → closer to 571px
News cards had \`min-width: 280px\` at desktop, but original cards are \`249px\` wide at 1728. The forced minimum prevented proper shrinking within the \`calc((100% - 4*gap) / 5)\` flex sizing, making cards wider → images taller → cards taller (689px vs original 571px). Fixed by setting \`min-width: 0\` at desktop.

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-3-news-explore-cta-pill--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] "Explore more news" button text is visible (dark text on white pill)
- [ ] Arrow icon still visible on the button
- [ ] News cards are narrower (~249px) and shorter (~571px)
- [ ] Card images maintain portrait aspect ratio
- [ ] Verify at 1728×1117 and 3440×1440

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)