### PR TITLE
Fix #106: Card Carousel — dark text, remove white gradient overlay

### DIFF
--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -35,7 +35,7 @@ main .card-carousel .card-carousel-card-bg img {
   object-fit: cover;
 }
 
-/* Content — sits above background */
+/* Content — sits above background, no gradient overlay (original has none) */
 main .card-carousel .card-carousel-card-content {
   position: relative;
   z-index: 1;
@@ -43,26 +43,23 @@ main .card-carousel .card-carousel-card-content {
   flex-direction: column;
   gap: var(--spacing-xs);
   padding: 40px;
-  background: linear-gradient(
-    to top,
-    rgb(255 255 255 / 95%) 0%,
-    rgb(255 255 255 / 85%) 60%,
-    rgb(255 255 255 / 40%) 100%
-  );
+  background: transparent;
 }
 
-/* Title — dark text, 28px */
+/* Title — dark text, must override .section.dark-alt color inheritance */
+main .section.dark-alt .card-carousel .card-carousel-card-title,
 main .card-carousel .card-carousel-card-title {
-  color: var(--text-color);
+  color: #292d3a;
   font-size: var(--heading-font-size-m);
   font-weight: 500;
   line-height: 1.2;
   margin: 0;
 }
 
-/* Description — grey text */
+/* Description — grey text, must override section inheritance */
+main .section.dark-alt .card-carousel .card-carousel-card-desc,
 main .card-carousel .card-carousel-card-desc {
-  color: var(--text-secondary-color);
+  color: #67686e;
   font-size: var(--body-font-size-l);
   line-height: 1.5;
   margin: 0;
@@ -73,8 +70,9 @@ main .card-carousel .card-carousel-card-cta-wrap {
   margin-top: var(--spacing-xs);
 }
 
+main .section.dark-alt .card-carousel .card-carousel-card-cta,
 main .card-carousel .card-carousel-card-cta {
-  color: var(--color-hpe-green);
+  color: #068667;
   font-size: var(--body-font-size-l);
   font-weight: 500;
   text-decoration: none;


### PR DESCRIPTION
## Summary

### Root cause
Same pattern as Issue #104: \`.section.dark-alt\` inherits white color to all children. Block-level selectors \`main .card-carousel .card-carousel-card-title { color: var(--text-color) }\` lost the specificity war against \`main .section.dark-alt h4 { color: white }\`.

Additionally, the content area had a white gradient background overlay that the original does not have (original cards have transparent content bg — text floats directly over the image).

### Fixes
1. **Content bg:** white gradient → \`transparent\`
2. **Title color:** explicit \`#292d3a\` with \`main .section.dark-alt .card-carousel\` specificity
3. **Description color:** explicit \`#67686e\` with same specificity pattern
4. **CTA color:** explicit \`#068667\` with same specificity pattern

All color values verified from original via devtools at 1728×1117.

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-5-card-carousel-text-color--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Card H4 title is dark text (not white)
- [ ] Card description is grey text (not white)
- [ ] Card CTA is green text (not white)
- [ ] No white gradient wash over card images
- [ ] Verify at 1728×1117

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)