### PR TITLE
Fix #103: Hero letter-spacing 1.92px, CTA padding 20px

### DIFF
--- a/blocks/hero-carousel/hero-carousel.css
+++ b/blocks/hero-carousel/hero-carousel.css
@@ -146,7 +146,7 @@ main .hero-carousel .hero-carousel-cta a.button {
   color: var(--dark-color);
   border: none;
   border-radius: 100px;
-  padding: 18px 36px;
+  padding: 20px 36px;
   font-size: 20px;
   font-weight: 500;
   text-decoration: none;
@@ -261,7 +261,7 @@ main .hero-carousel .hero-carousel-next::after {
     font-size: 96px;
     font-weight: 700;
     font-stretch: 75%;
-    letter-spacing: 1.6px;
+    letter-spacing: 1.92px;
     line-height: 96px;
     max-width: 640px;
   }


### PR DESCRIPTION
## Summary
Two pixel-level fixes verified via devtools on original at 1728×1117:
- H1 \`letter-spacing\`: \`1.6px\` → \`1.92px\`
- CTA \`padding\`: \`18px 36px\` → \`20px 36px\`

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-2-hero-spacing-padding--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Hero H1 letter-spacing matches original (1.92px)
- [ ] Hero CTA button slightly taller (20px top/bottom padding)

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)