### PR TITLE
Fix #108: Product Cards two-up — full-width stacked, H3 36px

### DIFF
--- a/blocks/product-cards/product-cards.css
+++ b/blocks/product-cards/product-cards.css
@@ -58,7 +58,7 @@ main .product-cards .product-card-content {
 }
 
 main .product-cards .product-card-content h3 {
-  font-size: var(--heading-font-size-l);
+  font-size: 36px;
   font-weight: 500;
   color: var(--text-color);
   margin: 0;
@@ -127,10 +127,10 @@ main .product-cards .product-card-link:hover::after {
     padding: var(--spacing-xl);
   }
 
-  /* Two-up variant: 2 horizontal cards in a grid row */
+  /* Two-up variant: full-width stacked cards (original is NOT a 2-col grid) */
   main .product-cards.two-up {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    display: flex;
+    flex-direction: column;
   }
 
   /* Three-up variant: 3 horizontal cards in a grid row */


### PR DESCRIPTION
## Summary

Original product cards (Networking, Software) are **full-width block elements stacked vertically** — NOT a 2-column grid. Verified via devtools: card width \`1728px\`, display \`block\`.

### Changes
- \`.product-cards.two-up\`: \`grid repeat(2, 1fr)\` → \`flex column\` (each card full section width)
- H3 fontSize: \`var(--heading-font-size-l)\` (32px) → explicit \`36px\` (matching original)
- Three-up variant (\`.product-cards.three-up\`) remains as \`repeat(3, 1fr)\` grid — original 3-up IS a grid

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-7-product-cards-fullwidth--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Networking + Software cards are full-width, stacked vertically
- [ ] Each card: image left (~42%), text right
- [ ] H3 "Networking" / "Software" renders at 36px
- [ ] Storage/Compute/Supercomputing (three-up) still renders as 3-column grid
- [ ] Verify at 1728×1117

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)