### PR TITLE
Fix #107: Customer Stories — transparent bg, dark H2, dark pill CTA

### DIFF
--- a/blocks/customer-stories/customer-stories.css
+++ b/blocks/customer-stories/customer-stories.css
@@ -1,9 +1,14 @@
-/* Customer Stories block — dark tabbed interface */
+/* Customer Stories block — original has transparent bg with dark text.
+   JS adds .customer-stories-light to section to override dark context. */
+
+/* Override section dark bg */
+main > .section.customer-stories-light {
+  background-color: transparent;
+  color: var(--text-color);
+}
 
 /* Block container */
 main .customer-stories {
-  background-color: var(--dark-color);
-  color: var(--text-light-color);
   padding: var(--spacing-xl) 0;
 }
 
@@ -18,30 +23,32 @@ main .customer-stories .customer-stories-header {
 }
 
 main .customer-stories .customer-stories-header h2 {
-  color: var(--text-light-color);
+  color: #292d3a;
   font-size: var(--heading-font-size-xl);
   margin-bottom: var(--spacing-xs);
 }
 
 main .customer-stories .customer-stories-header p {
-  color: rgb(255 255 255 / 80%);
+  color: var(--text-secondary-color);
   font-size: var(--body-font-size-m);
   line-height: 1.5;
   margin-bottom: 0;
 }
 
-main .customer-stories .customer-stories-header-cta .button {
-  background-color: transparent;
-  border: 2px solid var(--text-light-color);
+/* CTA: dark pill matching original (bg: #292d3a, pad: 20px 36px) */
+main .section.customer-stories-light .customer-stories-header-cta .button {
+  background-color: #292d3a;
+  border: none;
   color: var(--text-light-color);
-  font-size: var(--body-font-size-s);
-  padding: 10px 24px;
+  font-size: var(--body-font-size-l);
+  padding: 20px 36px;
   white-space: nowrap;
+  border-radius: 100px;
 }
 
-main .customer-stories .customer-stories-header-cta .button:hover {
-  background-color: var(--text-light-color);
-  color: var(--dark-color);
+main .section.customer-stories-light .customer-stories-header-cta .button:hover {
+  background-color: #1d1f27;
+  color: var(--text-light-color);
 }
 
 @media (width >= 900px) {

--- a/blocks/customer-stories/customer-stories.js
+++ b/blocks/customer-stories/customer-stories.js
@@ -283,4 +283,10 @@ export default async function decorate(block) {
   block.append(header);
   block.append(tablist);
   block.append(panelsContainer);
+
+  // Override dark section context — original has transparent bg with dark text
+  const section = block.closest('.section');
+  if (section) {
+    section.classList.add('customer-stories-light');
+  }
 }


### PR DESCRIPTION
## Summary

Same root cause pattern as Feature Banner (#105): section metadata says \`dark\` but original renders with transparent background and dark text.

### Original (verified via devtools at 1728×1117):
- Section bg: \`transparent\`
- H2 color: \`rgb(41,45,58)\` dark
- H2 fontSize: \`52px\`
- CTA: dark pill \`bg: #292d3a\`, \`padding: 20px 36px\`, \`borderRadius: 100px\`
- Tabs: black text, 18px, weight 400 (already fixed in PR #98)

### Fix:
- **JS:** \`customer-stories.js\` adds \`.customer-stories-light\` class to parent section
- **CSS:** \`.section.customer-stories-light\` overrides dark bg to \`transparent\`
- H2 color: explicit \`#292d3a\`
- Description: \`text-secondary-color\` (grey)
- CTA: dark pill (was white-bordered outline)

### Note on T-16/T-17 (10-column masonry grid + horizontal drag):
These structural tasks are deferred. The current 3-column grid is a functional approximation. Full 10-column masonry would require a complete JS rewrite of the panel builder, which is a separate scope. The visual context fixes in this PR are the highest-impact changes.

## Comparison URLs
- **Before:** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After:** https://issue-6-customer-stories-overhaul--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Section background is transparent (not dark)
- [ ] H2 "Customer stories" is dark text
- [ ] "View all customer stories" CTA is dark pill with white text
- [ ] Tab text is black/dark (not white)
- [ ] Panel content tiles still render
- [ ] Verify at 1728×1117

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)