### PR TITLE
fix: News carousel parity — card size, CTA color, full-width, heading

### DIFF
--- a/blocks/news-carousel/news-carousel.css
+++ b/blocks/news-carousel/news-carousel.css
@@ -26,11 +26,12 @@ main .news-carousel .news-carousel-hero img {
   max-height: 500px;
 }
 
-/* Heading */
+/* Heading — matches original: 52px/500/white/-1.04px */
 main .news-carousel .news-carousel-heading {
   color: var(--text-light-color);
   font-size: var(--heading-font-size-xl);
   font-weight: 500;
+  letter-spacing: -1.04px;
   margin-bottom: var(--spacing-l);
 }
 
@@ -89,14 +90,14 @@ main .news-carousel .news-carousel-track-wrapper.at-end::after {
 
 /* Individual card — text-only dark tile matching original (720×398) */
 main .news-carousel .news-carousel-card {
-  flex: 0 0 700px;
-  min-width: 700px;
+  flex: 0 0 720px;
+  min-width: 720px;
   min-height: 398px;
   background-color: var(--dark-alt-color);
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: clip;
 }
 
 /* Card image — hidden (original has no images in cards, just text tiles) */
@@ -130,14 +131,14 @@ main .news-carousel .news-carousel-card-description {
   line-height: 1.4;
 }
 
-/* Card CTA link — green with arrow */
+/* Card CTA link — white text with green arrow matching original dark card style */
 main .news-carousel .news-carousel-card-cta-wrap {
   margin-top: auto;
   padding-top: var(--spacing-xs);
 }
 
 main .news-carousel .news-carousel-card-cta {
-  color: var(--color-hpe-green);
+  color: var(--text-light-color);
   font-size: var(--body-font-size-m);
   font-weight: 500;
   text-decoration: none;
@@ -159,7 +160,7 @@ main .news-carousel .news-carousel-card-cta::after {
 }
 
 main .news-carousel .news-carousel-card-cta:hover {
-  color: var(--color-hpe-green-hover);
+  color: var(--color-hpe-green);
 }
 
 main .news-carousel .news-carousel-card-cta:hover::after {
@@ -303,8 +304,8 @@ main .news-carousel .news-carousel-explore:hover::after {
 /* === Desktop (900px+) === */
 @media (width >= 900px) {
   main .news-carousel .news-carousel-card {
-    flex: 0 0 700px;
-    min-width: 700px;
+    flex: 0 0 720px;
+    min-width: 720px;
     min-height: 398px;
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -373,6 +373,12 @@ main > .section.news-carousel-container {
   padding: 48px 0 40px;
 }
 
+/* News carousel spans full viewport width */
+main > .section.news-carousel-container > .news-carousel-wrapper {
+  max-width: unset;
+  padding: 0 var(--content-padding);
+}
+
 main > .section.feature-banner-container {
   padding: 20px 0;
 }


### PR DESCRIPTION
## Summary

News carousel section parity fixes based on devtools comparison with original at XPath `/html/body/div[3]/main/div[4]/div/div/div[2]/div/div/div[2]`.

## Test URLs

| | URL |
|---|---|
| **Before (main)** | https://main--summit-hpp--aemdemos.aem.page/us/en/home |
| **After (branch)** | https://fix-news-carousel-parity--summit-hpp--aemdemos.aem.page/us/en/home |
| **Original** | https://www.hpe.com/us/en/home.html |

## Changes

- **Card width**: 700→720px matching original exactly
- **Card overflow**: `hidden`→`clip` matching original
- **Card CTA link color**: green→white matching original dark card style (hover→green)
- **Section full-width**: wrapper `max-width: unset` with `padding: 0 160px`
- **Heading letter-spacing**: added `-1.04px` matching original

## Verification (devtools at 1728×1117)

| Property | Original | EDS | Match |
|----------|----------|-----|-------|
| Card width | 720px | 720px | ✅ |
| Card height | 398px | 398px | ✅ |
| Card bg | rgb(41,45,58) | rgb(41,45,58) | ✅ |
| Card overflow | clip | clip | ✅ |
| Card CTA color | white | white | ✅ |
| Heading | 52px/500/-1.04px | 52px/500/-1.04px | ✅ |
| Section width | 1728px | 1728px | ✅ |
| Explore btn | white pill | white pill | ✅ |
| Gradients | conditional | conditional | ✅ |

## Test plan

- [ ] Cards render as 720×398 text-only dark tiles
- [ ] Card CTA links are white, hover green
- [ ] Section spans full 1728px viewport
- [ ] "Explore more news" is white pill button
- [ ] Gradient overlays toggle on scroll
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)