### PR TITLE
content: import quantum bento box from original HPE homepage

### DIFF
--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -1,6 +1,27 @@
 /* Card Carousel — bento grid layout matching original HPE "bentoBox"
-   Original: CSS Grid, 2-column layout, cards with bg images,
-   dark text on transparent bg, ~598×373px cards at 1728px viewport */
+   Grid: 5 cards in asymmetric 2-row bento arrangement
+   Card 5 (tall) spans both rows on the right side */
+
+/* Section header — "The quantum era is here" sits above the block */
+main > .section.card-carousel-container .default-content-wrapper h3 {
+  font-size: 36px;
+  font-weight: 500;
+  letter-spacing: -0.36px;
+  line-height: 1.17;
+  margin: 0;
+}
+
+main > .section.card-carousel-container .default-content-wrapper p {
+  font-size: var(--body-font-size-l);
+  line-height: 1.5;
+  letter-spacing: -0.2px;
+  margin: 0;
+  padding-top: var(--spacing-m);
+}
+
+main > .section.card-carousel-container .default-content-wrapper {
+  margin-bottom: 48px;
+}
 
 /* Grid container */
 main .card-carousel .card-carousel-grid {
@@ -16,7 +37,7 @@ main .card-carousel .card-carousel-card {
   border-radius: 0;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: space-between;
   min-height: 320px;
 }
 
@@ -35,44 +56,47 @@ main .card-carousel .card-carousel-card-bg img {
   object-fit: cover;
 }
 
-/* Content — sits above background, no gradient overlay (original has none) */
+/* Content overlay — white text on image */
 main .card-carousel .card-carousel-card-content {
   position: relative;
   z-index: 1;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
-  padding: 32px;
+  padding: 40px;
   background: transparent;
 }
 
-/* Title — dark text, must override .section.dark-alt color inheritance */
+/* Title — white on dark image */
 main .section.dark-alt .card-carousel .card-carousel-card-title,
 main .card-carousel .card-carousel-card-title {
-  color: #292d3a;
+  color: var(--text-light-color);
   font-size: var(--heading-font-size-m);
   font-weight: 500;
-  line-height: 1.2;
+  letter-spacing: -0.28px;
+  line-height: 1.21;
   margin: 0;
 }
 
-/* Description — grey text, must override section inheritance */
+/* Description — light grey */
 main .section.dark-alt .card-carousel .card-carousel-card-desc,
 main .card-carousel .card-carousel-card-desc {
-  color: #67686e;
+  color: #e5e5e5;
   font-size: var(--body-font-size-l);
+  letter-spacing: -0.2px;
   line-height: 1.5;
   margin: 0;
 }
 
-/* CTA link — green with arrow */
+/* CTA link — bright teal green with arrow */
 main .card-carousel .card-carousel-card-cta-wrap {
-  margin-top: var(--spacing-xs);
+  margin-top: auto;
+  padding-top: var(--spacing-s);
 }
 
 main .section.dark-alt .card-carousel .card-carousel-card-cta,
 main .card-carousel .card-carousel-card-cta {
-  color: #068667;
+  color: #00e0af;
   font-size: var(--body-font-size-l);
   font-weight: 500;
   text-decoration: none;
@@ -84,9 +108,9 @@ main .card-carousel .card-carousel-card-cta {
 main .card-carousel .card-carousel-card-cta::after {
   content: '';
   display: inline-block;
-  width: 12px;
-  height: 12px;
-  background-color: var(--color-hpe-green);
+  width: 14px;
+  height: 14px;
+  background-color: #00e0af;
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
   /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
@@ -94,12 +118,12 @@ main .card-carousel .card-carousel-card-cta::after {
 }
 
 main .card-carousel .card-carousel-card-cta:hover {
-  color: var(--color-hpe-green-hover);
+  color: var(--text-light-color);
   text-decoration: underline;
 }
 
 main .card-carousel .card-carousel-card-cta:hover::after {
-  background-color: var(--color-hpe-green-hover);
+  background-color: var(--text-light-color);
   transform: translateX(4px);
 }
 
@@ -107,34 +131,78 @@ main .card-carousel .card-carousel-card-cta:hover::after {
 @media (width >= 600px) {
   main .card-carousel .card-carousel-grid {
     grid-template-columns: repeat(2, 1fr);
-    gap: var(--spacing-l);
+    gap: 32px;
   }
 
   main .card-carousel .card-carousel-card {
-    min-height: 360px;
-  }
-}
-
-/* === Desktop: 2 columns, bento height ~837px === */
-@media (width >= 900px) {
-  main .card-carousel .card-carousel-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 16px;
-  }
-
-  main .card-carousel .card-carousel-card {
-    min-height: 250px;
+    min-height: 351px;
   }
 
   main .card-carousel .card-carousel-card-title {
     font-size: 28px;
   }
+}
 
-  main .card-carousel .card-carousel-card-desc {
-    font-size: var(--body-font-size-l);
+/* === Desktop: bento grid matching original (4-col, 2-row) === */
+@media (width >= 900px) {
+  main .card-carousel .card-carousel-grid {
+    grid-template-columns: 3fr 1.2fr 2.5fr 2.8fr;
+    grid-template-rows: 351px 351px;
+    gap: 32px;
   }
 
-  main .card-carousel .card-carousel-card-cta {
-    font-size: var(--body-font-size-l);
+  /* Card 1 — spans 2 columns, row 1 */
+  main .card-carousel .card-carousel-card:nth-child(1) {
+    grid-column: 1 / 3;
+    grid-row: 1;
+  }
+
+  /* Card 2 — col 3, row 1 */
+  main .card-carousel .card-carousel-card:nth-child(2) {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  /* Card 3 — col 4, row 1 — hidden behind tall card 5 */
+
+  /* Card 5 occupies col 4 spanning both rows, so card 3 shifts */
+
+  /* Card 3 — col 1, row 2 */
+  main .card-carousel .card-carousel-card:nth-child(3) {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  /* Card 4 — spans cols 2-3, row 2 */
+  main .card-carousel .card-carousel-card:nth-child(4) {
+    grid-column: 2 / 4;
+    grid-row: 2;
+  }
+
+  /* Card 5 (tall) — col 4, spans both rows */
+  main .card-carousel .card-carousel-card:nth-child(5) {
+    grid-column: 4;
+    grid-row: 1 / 3;
+    min-height: 734px;
+  }
+
+  /* Tall card: image on top, text below */
+  main .card-carousel .card-carousel-card:nth-child(5) .card-carousel-card-bg {
+    position: relative;
+    height: 236px;
+    flex: 0 0 auto;
+  }
+
+  main .card-carousel .card-carousel-card:nth-child(5) .card-carousel-card-content {
+    flex: 1;
+  }
+
+  main .card-carousel .card-carousel-card {
+    min-height: 351px;
+  }
+
+  main .card-carousel .card-carousel-card-title {
+    font-size: 28px;
+    letter-spacing: -0.28px;
   }
 }

--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -2,6 +2,16 @@
    Grid: 5 cards in asymmetric 2-row bento arrangement
    Card 5 (tall) spans both rows on the right side */
 
+/* Force light background — override any dark-alt section metadata */
+main > .section.card-carousel-container {
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+main > .section.card-carousel-container h3 {
+  color: var(--text-color);
+}
+
 /* Section header — "The quantum era is here" sits above the block */
 main > .section.card-carousel-container .default-content-wrapper h3 {
   font-size: 36px;
@@ -12,6 +22,7 @@ main > .section.card-carousel-container .default-content-wrapper h3 {
 }
 
 main > .section.card-carousel-container .default-content-wrapper p {
+  color: var(--text-secondary-color);
   font-size: var(--body-font-size-l);
   line-height: 1.5;
   letter-spacing: -0.2px;

--- a/blocks/card-carousel/card-carousel.css
+++ b/blocks/card-carousel/card-carousel.css
@@ -41,7 +41,7 @@ main .card-carousel .card-carousel-grid {
   gap: var(--spacing-m);
 }
 
-/* Individual card */
+/* Individual card — dark background matches original bb-bg */
 main .card-carousel .card-carousel-card {
   position: relative;
   overflow: hidden;
@@ -50,6 +50,7 @@ main .card-carousel .card-carousel-card {
   flex-direction: column;
   justify-content: space-between;
   min-height: 320px;
+  background-color: var(--dark-alt-color);
 }
 
 /* Background image — fills entire card */

--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -3,18 +3,9 @@
    .feature-banner-dark (h2) — "HPE Services" — dark-alt bg, white text, white pill CTA, teal gradient
    Note: nested :has() is invalid in CSS — variants use JS-applied classes instead. */
 
-/* === LIGHT VARIANT (.feature-banner-light on section) === */
+/* === LIGHT VARIANT — deprecated / hidden === */
 main > .section.feature-banner-light {
-  background-color: var(--background-color);
-  color: var(--text-color);
-}
-
-main > .section.feature-banner-light h3 {
-  color: var(--text-color);
-}
-
-main > .section.feature-banner-light p {
-  color: var(--text-secondary-color);
+  display: none;
 }
 
 /* === DARK VARIANT (.feature-banner-dark on section) ===

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -388,7 +388,7 @@ main > .section.section-header-container {
 }
 
 main > .section.card-carousel-container {
-  padding: 24px 0;
+  padding: 48px 0;
 }
 
 main > .section.greenlake-promo-container {


### PR DESCRIPTION
## Summary
- Replaces deprecated "AI for every use case" feature-banner + AI card-carousel with **quantum-themed bento box** from the current HPE homepage
- Header ("The quantum era is here" + description) placed as regular section content **before** the card-carousel block
- 5 cards imported with original images from HPE DAM:
  1. Setonix supercomputer quantum breakthroughs
  2. Beyond the qubit: utility scale quantum computing
  3. The road to quantum advantage
  4. Argonne national laboratory quantum information science
  5. HPE Cray: hybrid quantum-supercomputing era
- Hides deprecated feature-banner light variant via CSS

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://import-quantum-bento-box--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify "AI for every use case" section is hidden
- [ ] Verify quantum header appears above card carousel
- [ ] Verify 5 quantum cards render with correct images and CTAs
- [ ] Verify HPE Services feature-banner (dark variant) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)