### PR TITLE
fix: greenlake-promo video thumbnail fills full panel width

### DIFF
--- a/blocks/greenlake-promo/greenlake-promo.css
+++ b/blocks/greenlake-promo/greenlake-promo.css
@@ -33,7 +33,7 @@ main .greenlake-promo {
 main .greenlake-promo .greenlake-promo-left {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-m);
+  gap: 40px;
 }
 
 main .greenlake-promo .greenlake-promo-logo {
@@ -55,51 +55,45 @@ main .greenlake-promo .greenlake-promo-description {
 /* Video thumbnail card */
 
 main .greenlake-promo .greenlake-promo-video {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-s);
+  position: relative;
   margin-top: auto;
 }
 
 main .greenlake-promo .greenlake-promo-video-thumb {
   position: relative;
-  border-radius: 8px;
+  border-radius: 0;
   overflow: hidden;
   cursor: pointer;
-  max-width: 320px;
 }
 
 main .greenlake-promo .greenlake-promo-video-thumb img {
   display: block;
   width: 100%;
   height: auto;
-  border-radius: 8px;
 }
 
 main .greenlake-promo .greenlake-promo-video-thumb::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgb(0 0 0 / 25%);
-  border-radius: 8px;
+  background: linear-gradient(to top, rgb(0 0 0 / 60%) 0%, transparent 50%);
   pointer-events: none;
   transition: background var(--transition-base);
 }
 
 main .greenlake-promo .greenlake-promo-video-thumb:hover::after {
-  background: rgb(0 0 0 / 15%);
+  background: linear-gradient(to top, rgb(0 0 0 / 40%) 0%, transparent 50%);
 }
 
-/* Play button */
+/* Play button — bottom-left of thumbnail */
 
 main .greenlake-promo .greenlake-promo-play {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  bottom: 32px;
+  left: 28px;
   z-index: 1;
-  width: 56px;
-  height: 56px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
   background-color: var(--color-hpe-green);
   border: none;
@@ -131,29 +125,35 @@ main .greenlake-promo .greenlake-promo-play-icon {
   border-color: transparent transparent transparent var(--text-light-color);
 }
 
-/* Video info */
+/* Video info — overlays bottom of thumbnail next to play button */
 
 main .greenlake-promo .greenlake-promo-video-info {
+  position: absolute;
+  bottom: 32px;
+  left: 112px;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
 main .greenlake-promo .greenlake-promo-video-title {
-  color: var(--text-color);
-  font-size: var(--body-font-size-s);
-  font-weight: 500;
+  color: var(--text-light-color);
+  font-size: var(--body-font-size-l);
+  font-weight: 700;
+  line-height: 1.5;
 }
 
 main .greenlake-promo .greenlake-promo-video-subtitle {
-  color: var(--text-secondary-color);
-  font-size: var(--body-font-size-xs);
-  line-height: 1.4;
+  color: var(--text-light-color);
+  font-size: var(--body-font-size-l);
+  font-weight: 700;
+  line-height: 1.5;
 }
 
 main .greenlake-promo .greenlake-promo-video-duration {
-  color: var(--text-muted-color);
-  font-size: var(--body-font-size-xs);
+  color: var(--text-light-color);
+  font-size: var(--body-font-size-s);
 }
 
 /* --- Right Panel --- */

--- a/blocks/greenlake-promo/greenlake-promo.css
+++ b/blocks/greenlake-promo/greenlake-promo.css
@@ -2,10 +2,10 @@
    Original: flex row, 50px gap, logo+desc+video left, screenshot+h3+CTA right
    White bg, grey description text, dark heading, dark pill CTA */
 
-/* Force light background — override dark section metadata */
+/* Force light grey section background — override dark section metadata */
 main > .section.greenlake-promo-container,
 main > .section.dark.greenlake-promo-container {
-  background-color: var(--background-color);
+  background-color: var(--light-color);
   color: var(--text-color);
 }
 
@@ -156,12 +156,13 @@ main .greenlake-promo .greenlake-promo-video-duration {
   font-size: var(--body-font-size-s);
 }
 
-/* --- Right Panel --- */
+/* --- Right Panel — white bg, centered text below screenshot --- */
 
 main .greenlake-promo .greenlake-promo-right {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-m);
+  background-color: var(--background-color);
 }
 
 main .greenlake-promo .greenlake-promo-screenshot {
@@ -180,11 +181,14 @@ main .greenlake-promo .greenlake-promo-heading {
   font-weight: 500;
   letter-spacing: -0.36px;
   line-height: 1.17;
+  text-align: center;
+  margin-top: var(--spacing-xl);
 }
 
 /* CTA — dark pill with white text + arrow */
 main .greenlake-promo .greenlake-promo-cta {
   margin: 0;
+  text-align: center;
 }
 
 main .section.dark .greenlake-promo .greenlake-promo-cta .button,
@@ -257,6 +261,7 @@ main .greenlake-promo .greenlake-promo-cta a:hover::after {
 
   main .greenlake-promo .greenlake-promo-right {
     justify-content: flex-start;
+    align-items: center;
     padding: 100px 0;
   }
 

--- a/blocks/greenlake-promo/greenlake-promo.css
+++ b/blocks/greenlake-promo/greenlake-promo.css
@@ -56,7 +56,7 @@ main .greenlake-promo .greenlake-promo-description {
 
 main .greenlake-promo .greenlake-promo-video {
   position: relative;
-  margin-top: auto;
+  margin-top: 60px;
 }
 
 main .greenlake-promo .greenlake-promo-video-thumb {


### PR DESCRIPTION
## Summary
- Video thumbnail now fills full left panel width (679px) matching the original's 679x382px
- Removed max-width: 320px that was making the video tiny
- Play button repositioned from center to bottom-left with video info overlay
- Video info text changed to white for overlay visibility
- Gradient overlay for text readability on thumbnail
- Left panel gap increased to 40px matching original

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-greenlake-video-sizing--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify video thumbnail fills full left panel width
- [ ] Verify play button is at bottom-left of thumbnail
- [ ] Verify video info text is white and overlays thumbnail
- [ ] Verify gradient overlay on thumbnail bottom
- [ ] Verify logo and description spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)