### PR TITLE
fix: product-cards vertical stacked layout matching original

### DIFF
--- a/blocks/product-cards/product-cards.css
+++ b/blocks/product-cards/product-cards.css
@@ -1,26 +1,19 @@
-/* Product Cards — horizontal cards matching original HPE layout
-   Original: each card has image left ~42%, text right ~58% at desktop */
+/* Product Cards — vertical stacked cards matching original HPE layout.
+   Original: image on top, text below. 2-up row then 3-up row.
+   Cards are flat (no bg, no border, no shadow). */
 
 main .product-cards {
   display: flex;
-  flex-direction: column;
-  gap: var(--spacing-s);
+  flex-wrap: wrap;
+  gap: 48px 40px;
   padding: 0;
 }
 
-/* Card — vertical on mobile, horizontal at desktop */
+/* Card — image stacked above text */
 main .product-cards .product-card {
   display: flex;
   flex-direction: column;
-  background-color: var(--background-color);
-  border: 1px solid var(--border-light-color);
-  border-radius: 12px;
-  overflow: hidden;
-  transition: box-shadow var(--transition-slow);
-}
-
-main .product-cards .product-card:hover {
-  box-shadow: var(--shadow-lg);
+  flex: 1 1 100%;
 }
 
 /* Card image */
@@ -32,68 +25,62 @@ main .product-cards .product-card-image {
 main .product-cards .product-card-image picture {
   display: block;
   width: 100%;
-  height: 100%;
 }
 
 main .product-cards .product-card-image img {
   display: block;
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.6s ease;
-}
-
-main .product-cards .product-card:hover .product-card-image img {
-  transform: scale(1.03);
+  height: auto;
+  object-fit: fill;
 }
 
 /* Card content */
 main .product-cards .product-card-content {
   display: flex;
   flex-direction: column;
-  flex: 1;
-  padding: var(--spacing-l);
-  gap: var(--spacing-s);
-  justify-content: center;
+  gap: var(--spacing-m);
+  padding-top: var(--spacing-m);
 }
 
 main .product-cards .product-card-content h3 {
   font-size: 36px;
   font-weight: 500;
   color: var(--text-color);
+  letter-spacing: -0.36px;
+  line-height: 1.17;
   margin: 0;
 }
 
 main .product-cards .product-card-content p {
   color: var(--text-secondary-color);
-  font-size: var(--body-font-size-s);
+  font-size: var(--body-font-size-l);
   line-height: 1.5;
+  letter-spacing: -0.2px;
   margin: 0;
 }
 
 /* CTA link with green arrow */
 main .product-cards .product-card-cta {
-  margin-top: auto;
-  padding-top: var(--spacing-s);
+  margin: 0;
 }
 
 main .product-cards .product-card-link {
-  color: var(--color-hpe-green);
-  font-size: var(--body-font-size-s);
+  color: #068667;
+  font-size: var(--body-font-size-l);
   font-weight: 500;
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   transition: color var(--transition-base);
 }
 
 main .product-cards .product-card-link::after {
   content: '';
   display: inline-block;
-  width: 12px;
-  height: 12px;
-  background-color: var(--color-hpe-green);
+  width: 20px;
+  height: 20px;
+  background-color: #068667;
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
   /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
@@ -110,60 +97,27 @@ main .product-cards .product-card-link:hover::after {
   transform: translateX(4px);
 }
 
-/* Desktop: horizontal card layout */
+/* === Desktop: 2-up and 3-up grids === */
 @media (width >= 900px) {
-  main .product-cards .product-card {
-    flex-direction: row;
-    min-height: 190px;
-  }
-
-  main .product-cards .product-card-image {
-    flex: 0 0 38%;
-    min-height: 190px;
-  }
-
-  main .product-cards .product-card-content {
-    flex: 1;
-    padding: var(--spacing-m);
-  }
-
-  /* Two-up variant: full-width stacked cards (original is NOT a 2-col grid) */
+  /* Two-up: 2-column grid */
   main .product-cards.two-up {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    gap: 64px 40px;
   }
 
-  /* Three-up variant: compact stacked cards (original ~161px per card) */
+  main .product-cards.two-up .product-card {
+    flex: 0 0 calc(50% - 20px);
+  }
+
+  /* Three-up: 3-column grid */
   main .product-cards.three-up {
     display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
+    flex-wrap: wrap;
+    gap: 64px 40px;
   }
 
   main .product-cards.three-up .product-card {
-    min-height: 120px;
-  }
-
-  main .product-cards.three-up .product-card-image {
-    flex: 0 0 24%;
-    min-height: 120px;
-  }
-
-  main .product-cards.three-up .product-card-content {
-    padding: var(--spacing-s) var(--spacing-m);
-    gap: var(--spacing-xs);
-  }
-
-  main .product-cards.three-up .product-card-content h3 {
-    font-size: 28px;
-  }
-
-  main .product-cards.three-up .product-card-content p {
-    font-size: var(--body-font-size-xs);
-    line-height: 1.4;
-  }
-
-  main .product-cards.three-up .product-card-cta {
-    padding-top: var(--spacing-xs);
+    flex: 0 0 calc(33.3333% - 26.6667px);
   }
 }

--- a/blocks/section-header/section-header.css
+++ b/blocks/section-header/section-header.css
@@ -1,9 +1,7 @@
 /* Section Header — centered heading with description text */
 
 main .section-header {
-  max-width: 800px;
-  margin: 0 auto;
-  text-align: center;
+  text-align: left;
   padding-bottom: 0;
 }
 
@@ -13,8 +11,9 @@ main .section-header h2 {
 
 main .section-header p {
   color: var(--text-secondary-color);
-  font-size: var(--body-font-size-m);
-  line-height: 1.4;
+  font-size: var(--body-font-size-l);
+  line-height: 1.5;
+  letter-spacing: -0.2px;
   margin-bottom: 4px;
 }
 
@@ -36,7 +35,6 @@ main .section-header a:hover {
 
 @media (width >= 900px) {
   main .section-header {
-    max-width: 900px;
     padding-bottom: 0;
   }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -400,7 +400,7 @@ main > .section.customer-stories-container {
 }
 
 main > .section.product-cards-container {
-  padding: 8px 0 16px;
+  padding: 24px 0;
 }
 
 /* Hide empty trailing section (metadata section with no visible content) */


### PR DESCRIPTION
## Summary
Complete rewrite of product-cards styling to match the original HPE homepage:
- Cards changed from horizontal (image left, text right) to vertical stacked (image on top, text below)
- Two-up row: 2-column flex grid at calc(50% - 20px) per card
- Three-up row: 3-column flex grid at calc(33.3333% - 26.6667px) per card
- Gap: 64px row, 40px column
- Cards are flat content blocks (no border, no border-radius, no shadow)
- H3: 36px for all cards, body text: 20px, CTA: 20px green with 20px arrow

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-product-cards-styling--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify 2-up row shows 2 side-by-side vertical cards
- [ ] Verify 3-up row shows 3 side-by-side vertical cards
- [ ] Verify images are on top, text below
- [ ] Verify cards have no borders/shadows/backgrounds
- [ ] Verify CTA links are green with arrow icons
- [ ] Verify responsive stacking on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)