### PR TITLE
fix: feature-banner HPE Services marquee matching original

### DIFF
--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -1,68 +1,106 @@
-/* Feature Banner — two variants determined by JS-applied section classes:
-   .feature-banner-light (h3) — "AI for every use case" — white bg, dark text, dark pill CTA
-   .feature-banner-dark (h2) — "HPE Services" — dark-alt bg, white text, white pill CTA, teal gradient
-   Note: nested :has() is invalid in CSS — variants use JS-applied classes instead. */
+/* Feature Banner — two variants:
+   .feature-banner-light (h3) — deprecated / hidden
+   .feature-banner-dark (h2) — "HPE Services" marquee with bg image */
 
 /* === LIGHT VARIANT — deprecated / hidden === */
 main > .section.feature-banner-light {
   display: none;
 }
 
-/* === DARK VARIANT (.feature-banner-dark on section) ===
-   Full-bleed marquee layout matching original HPE Services section (895px).
-   Teal gradient accent simulates original background image. */
+/* === DARK VARIANT — HPE Services full-bleed marquee ===
+   Original: 895px tall, bg image covers full area, content vertically
+   centered on the left ~66% of the content area. White pill CTA. */
+
 main > .section.feature-banner-dark {
   position: relative;
   overflow: hidden;
-  min-height: 600px;
+  min-height: 895px;
   display: flex;
   align-items: center;
 }
 
-main .section.feature-banner-dark .feature-banner-inner {
+/* Background image fills entire section */
+main > .section:has(.feature-banner) > .bg-image {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+main > .section:has(.feature-banner) > .bg-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 50% 50%;
+}
+
+/* Content sits above background */
+main .section.feature-banner-dark .feature-banner {
   position: relative;
   z-index: 1;
 }
 
-/* Dark overlay on bg-image for readability + teal accent */
-main .section.feature-banner-dark .feature-banner::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(135deg, rgb(41 45 58 / 85%) 0%, rgb(41 45 58 / 50%) 60%),
-    linear-gradient(315deg, rgb(1 169 130 / 15%) 0%, transparent 50%);
-  pointer-events: none;
-  z-index: 0;
-}
-
 main .section.feature-banner-dark h2 {
   color: var(--text-light-color);
+  font-size: var(--heading-font-size-xl);
+  font-weight: 500;
+  letter-spacing: -1.04px;
+  line-height: 1.12;
+  margin: 0;
 }
 
 main .section.feature-banner-dark p {
-  color: rgb(255 255 255 / 80%);
+  color: #e5e5e5;
+  font-size: var(--body-font-size-l);
+  line-height: 1.5;
+  letter-spacing: -0.2px;
+  margin: 0;
 }
 
 /* HPE Services CTA: white pill with dark text + arrow */
 main .section.feature-banner-dark .feature-banner a.button,
 main .section.feature-banner-dark .feature-banner a {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
   background-color: white;
-  color: var(--dark-color);
+  color: var(--dark-alt-color);
+  border: none;
+  border-radius: 100px;
+  padding: 20px 36px;
+  font-size: var(--body-font-size-l);
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s;
+  width: fit-content;
+  margin: 0;
 }
 
 main .section.feature-banner-dark .feature-banner a.button:hover,
 main .section.feature-banner-dark .feature-banner a:hover {
   background-color: #e5e5e5;
-  color: var(--dark-color);
+  color: var(--dark-alt-color);
+  text-decoration: none;
 }
 
 main .section.feature-banner-dark .feature-banner a.button::after,
 main .section.feature-banner-dark .feature-banner a::after {
-  background-color: var(--dark-color);
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background-color: var(--dark-alt-color);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  transition: transform 0.2s;
+}
+
+main .section.feature-banner-dark .feature-banner a:hover::after {
+  transform: translateX(4px);
 }
 
 /* === SHARED BASE STYLES === */
+
 main .feature-banner {
   padding: 0;
   text-align: left;
@@ -72,14 +110,6 @@ main .feature-banner > div {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-m);
-}
-
-/* H3 (light variant): 36px — matches original devtools value.
-   H2 (dark variant): uses --heading-font-size-xl (52px). */
-main .feature-banner h3 {
-  font-size: 36px;
-  font-weight: 500;
-  margin: 0;
 }
 
 main .feature-banner h2 {
@@ -94,71 +124,28 @@ main .feature-banner p {
   margin: 0;
 }
 
-/* CTA: default dark pill with white text + arrow */
-main .feature-banner a.button,
-main .feature-banner a {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  background-color: var(--dark-color);
-  color: var(--text-light-color);
-  border: none;
-  border-radius: 100px;
-  padding: 20px 36px;
-  font-size: var(--body-font-size-l);
-  font-weight: 500;
-  text-decoration: none;
-  transition: background-color 0.2s;
-  width: fit-content;
-}
+/* === Desktop (900px+) === */
 
-main .feature-banner a.button:hover,
-main .feature-banner a:hover {
-  background-color: var(--text-color);
-  text-decoration: none;
-  color: var(--text-light-color);
-}
-
-main .feature-banner a.button::after,
-main .feature-banner a::after {
-  content: '';
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  background-color: var(--text-light-color);
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
-  transition: transform 0.2s;
-}
-
-main .feature-banner a.button:hover::after,
-main .feature-banner a:hover::after {
-  transform: translateX(4px);
-}
-
-/* Desktop — light variant is compact row, dark variant stays stacked marquee */
 @media (width >= 900px) {
   main .feature-banner {
     padding: 0;
   }
 
-  main .feature-banner > div {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  /* Dark variant: keep stacked layout for marquee feel */
+  /* Dark variant: stacked column layout, content on left ~66% */
   main .section.feature-banner-dark .feature-banner > div {
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--spacing-l);
-    max-width: 720px;
+    gap: 40px;
+    max-width: 940px;
+  }
+
+  /* CTA gets 32px top margin (separate from the 40px gap above) */
+  main .section.feature-banner-dark .feature-banner > div > p:last-child {
+    margin-top: -8px;
   }
 
   main > .section.feature-banner-dark {
-    min-height: 680px;
-    padding: 100px 0;
+    min-height: 895px;
+    padding: 60px 0;
   }
 }


### PR DESCRIPTION
## Summary
Complete rewrite of the HPE Services feature-banner dark variant to match the original:
- Section height: 895px (was 680px)
- Background image: removed CSS gradient overlays, let bg-image show through with object-fit cover
- Content max-width: 940px (was 720px) — matches original's 66% content column
- Description color: #e5e5e5 (was white/80%)
- CTA arrow icon: 20px (was 14px)
- Heading→description gap: 40px (was 32px)
- H2: added -1.04px letter-spacing

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-feature-banner-services--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify HPE Services section is ~895px tall
- [ ] Verify background image shows through without gradient overlay
- [ ] Verify white pill CTA with dark text and 20px arrow
- [ ] Verify content is left-aligned and vertically centered
- [ ] Verify description is #e5e5e5 color

🤖 Generated with [Claude Code](https://claude.com/claude-code)