### PR TITLE
fix: loose ends — products spacing, services positioning, footer fonts

### DIFF
--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -144,11 +144,10 @@ main .feature-banner p {
     margin-top: 16px;
   }
 
-  /* Content shifted up via asymmetric padding */
+  /* Content vertically centered with 60px padding */
   main > .section.feature-banner-dark {
     min-height: 895px;
-    padding: 0;
-    align-items: flex-start;
-    padding-top: 180px;
+    padding: 60px 0;
+    align-items: center;
   }
 }

--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -139,13 +139,16 @@ main .feature-banner p {
     max-width: 940px;
   }
 
-  /* CTA gets 32px top margin (separate from the 40px gap above) */
+  /* CTA nudged down from text */
   main .section.feature-banner-dark .feature-banner > div > p:last-child {
-    margin-top: -8px;
+    margin-top: 16px;
   }
 
+  /* Content shifted up via asymmetric padding */
   main > .section.feature-banner-dark {
     min-height: 895px;
-    padding: 60px 0;
+    padding: 0;
+    align-items: flex-start;
+    padding-top: 180px;
   }
 }

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -65,7 +65,7 @@ footer .footer .footer-actions {
 
 footer .footer .footer-action-link {
   color: var(--text-light-color);
-  font-size: var(--body-font-size-xs);
+  font-size: var(--body-font-size-s);
   padding: 6px 0;
 }
 
@@ -73,9 +73,9 @@ footer .footer .footer-action-button {
   display: inline-block;
   border: 1px solid rgb(255 255 255 / 40%);
   border-radius: var(--button-border-radius);
-  padding: 6px 16px;
+  padding: 8px 20px;
   color: var(--text-light-color);
-  font-size: var(--body-font-size-xs);
+  font-size: var(--body-font-size-s);
   font-weight: 500;
   transition: border-color var(--transition-base), background-color var(--transition-base);
 }
@@ -162,7 +162,7 @@ footer .footer .footer-nav-toggle:hover {
 
 footer .footer .footer-nav-title {
   font-family: var(--heading-font-family);
-  font-size: var(--body-font-size-s);
+  font-size: var(--body-font-size-m);
   font-weight: 500;
   color: var(--text-light-color);
   text-transform: none;
@@ -204,7 +204,7 @@ footer .footer .footer-nav-list li {
 }
 
 footer .footer .footer-nav-list a {
-  font-size: var(--body-font-size-xs);
+  font-size: var(--body-font-size-s);
   color: rgb(255 255 255 / 80%);
   line-height: 1.8;
 }
@@ -232,7 +232,7 @@ footer .footer .footer-copyright {
 }
 
 footer .footer .footer-copyright-text {
-  font-size: 12px;
+  font-size: var(--body-font-size-xs);
   color: rgb(255 255 255 / 60%);
   margin: 0;
 }
@@ -258,7 +258,7 @@ footer .footer .footer-legal-list li:not(:last-child)::after {
 }
 
 footer .footer .footer-legal-list a {
-  font-size: 12px;
+  font-size: var(--body-font-size-xs);
   color: rgb(255 255 255 / 60%);
 }
 
@@ -271,7 +271,7 @@ footer .footer .footer-language {
 }
 
 footer .footer .footer-language-link {
-  font-size: 12px;
+  font-size: var(--body-font-size-xs);
   color: rgb(255 255 255 / 60%);
   border: 1px solid rgb(255 255 255 / 30%);
   border-radius: 4px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -400,7 +400,7 @@ main > .section.customer-stories-container {
 }
 
 main > .section.product-cards-container {
-  padding: 24px 0;
+  padding: 24px 0 80px;
 }
 
 /* Hide empty trailing section (metadata section with no visible content) */


### PR DESCRIPTION
## Summary
Three loose end fixes:

1. **Products section**: Added 80px bottom padding for more visible white space below
2. **HPE Services feature-banner**: Button nudged down (16px extra margin), title+text nudged up (180px top padding with flex-start alignment)
3. **Footer font sizes increased**: Nav titles 16→18px, nav links 14→16px, action links/buttons 14→16px, copyright/legal 12→14px

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-loose-ends-spacing--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify more white space below products section
- [ ] Verify HPE Services button is lower, title+text are higher
- [ ] Verify footer text is larger and more readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)