### PR TITLE
fix: batch minor deltas — section heights, image ratios, footer spacing

### DIFF
--- a/blocks/feature-banner/feature-banner.css
+++ b/blocks/feature-banner/feature-banner.css
@@ -144,8 +144,9 @@ main .feature-banner p {
     margin-top: 16px;
   }
 
-  /* Content vertically centered with 60px padding */
+  /* Content vertically centered — box-sizing includes padding in height */
   main > .section.feature-banner-dark {
+    box-sizing: border-box;
     min-height: 895px;
     padding: 60px 0;
     align-items: center;

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -108,6 +108,21 @@ footer .footer .footer-action-button {
   font-weight: 500;
   background: transparent;
   transition: color var(--transition-base);
+  overflow: visible;
+  white-space: normal;
+  text-overflow: unset;
+}
+
+footer .footer .footer-action-button::after {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background-color: var(--text-light-color);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M17 8l4 4m0 0l-4 4m4-4H3'/%3E%3C/svg%3E") center/contain no-repeat;
+  flex-shrink: 0;
 }
 
 footer .footer .footer-action-button:hover {
@@ -236,7 +251,7 @@ footer .footer .footer-nav-toggle[aria-expanded="true"] + .footer-nav-list {
 }
 
 footer .footer .footer-nav-list li {
-  padding: 10px 0 0;
+  padding: 21px 0 0;
 }
 
 footer .footer .footer-nav-list a {

--- a/blocks/product-cards/product-cards.css
+++ b/blocks/product-cards/product-cards.css
@@ -16,10 +16,11 @@ main .product-cards .product-card {
   flex: 1 1 100%;
 }
 
-/* Card image */
+/* Card image — constrained to original's ~2.36:1 aspect ratio */
 main .product-cards .product-card-image {
   overflow: hidden;
   background-color: var(--light-color);
+  aspect-ratio: 2.36;
 }
 
 main .product-cards .product-card-image picture {
@@ -30,8 +31,8 @@ main .product-cards .product-card-image picture {
 main .product-cards .product-card-image img {
   display: block;
   width: 100%;
-  height: auto;
-  object-fit: fill;
+  height: 100%;
+  object-fit: cover;
 }
 
 /* Card content */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -391,12 +391,17 @@ main > .section.card-carousel-container {
   padding: 48px 0;
 }
 
+/* Solutions grid needs ~32px more padding to match original 847px */
+main > .section.solutions-grid-container {
+  padding: 112px 0;
+}
+
 main > .section.greenlake-promo-container {
-  padding: 100px 0 40px;
+  padding: 120px 0 60px;
 }
 
 main > .section.customer-stories-container {
-  padding: 130px 0;
+  padding: 176px 0;
 }
 
 main > .section.product-cards-container {


### PR DESCRIPTION
## Summary
Batch fix for remaining minor visual deltas identified in the full-page differential scan.

### Fixes
1. **Solutions Grid** +64px: section padding 80px → 112px
2. **GreenLake Promo** +50px: padding 100px/40px → 120px/60px
3. **Customer Stories** +46px: padding 130px → 176px
4. **Product card images** -102px: added aspect-ratio 2.36 with object-fit cover
5. **HPE Services** -120px: box-sizing border-box so min-height includes padding
6. **Footer nav items**: spacing 10px → 21px matching original
7. **Footer action buttons**: arrow icons + overflow reset

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-minor-deltas-batch--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Solutions grid section ~847px
- [ ] GreenLake promo ~972px
- [ ] Customer stories ~1540px
- [ ] Product card images match 2.36:1 ratio
- [ ] HPE Services section ~895px (not 1015px)
- [ ] Footer nav item spacing 21px
- [ ] Footer action buttons have arrow icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)