### PR TITLE
fix: add space between product-cards rows

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -405,7 +405,7 @@ main > .section.customer-stories-container {
 }
 
 main > .section.product-cards-container {
-  padding: 24px 0 80px;
+  padding: 48px 0 80px;
 }
 
 /* Hide empty trailing section (metadata section with no visible content) */


### PR DESCRIPTION
## Summary
Increases top padding on product-cards sections from 24px to 48px, adding visible white space between the two-up row (Networking, Software) and three-up row (Storage, Compute, Supercomputing).

## Before / After
- **Before (main):** https://main--summit-hpp--aemdemos.aem.page/us/en/home
- **After (branch):** https://fix-product-cards-gap--summit-hpp--aemdemos.aem.page/us/en/home

## Test plan
- [ ] Verify visible gap between 2-up and 3-up product card rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)